### PR TITLE
Allow to use @Named annotation without having to set the bean as @Primary

### DIFF
--- a/src/main/java/org/springframework/guice/module/SpringModule.java
+++ b/src/main/java/org/springframework/guice/module/SpringModule.java
@@ -110,8 +110,14 @@ public class SpringModule implements Module {
 		@Override
 		public Object get() {
 			if (this.result == null) {
-				String[] names = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(this.beanFactory, this.type);
-				if (names.length == 1) {
+
+				String[] named = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(this.beanFactory, this.type);
+				List<String> names = new ArrayList<>(named.length);
+				for (String name : named) {
+					if (name.equals(this.name)) names.add(name);
+				}
+
+				if (names.size() == 1) {
 					this.result = this.beanFactory.getBean(this.name, this.type);
 				}
 				else {


### PR DESCRIPTION
Correct me if I'm wrong but the purpose of having a named bean is to have multiple definitions of the same type allowing you to inject them by name.
Right now when you wanted to specify a named bean you had to set it to Primary too if you have other beans of the same type which I think makes the Named annotation useless.
Please review the pull request and see if it makes sense, it did the trick for me...
