### PR TITLE
support binding of generic interfaces from SpringModule

### DIFF
--- a/src/main/java/org/springframework/guice/module/BindingTypeMatcher.java
+++ b/src/main/java/org/springframework/guice/module/BindingTypeMatcher.java
@@ -16,12 +16,14 @@
 
 package org.springframework.guice.module;
 
+import java.lang.reflect.Type;
+
 /**
  * @author Dave Syer
  *
  */
 public interface BindingTypeMatcher {
 
-	boolean matches(String name, Class<?> type);
+	boolean matches(String name, Type type);
 
 }

--- a/src/main/java/org/springframework/guice/module/GuiceModuleMetadata.java
+++ b/src/main/java/org/springframework/guice/module/GuiceModuleMetadata.java
@@ -18,12 +18,14 @@ package org.springframework.guice.module;
 
 import java.io.IOException;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.type.classreading.CachingMetadataReaderFactory;
 import org.springframework.core.type.classreading.MetadataReader;
 import org.springframework.core.type.classreading.MetadataReaderFactory;
@@ -93,7 +95,7 @@ public class GuiceModuleMetadata implements BindingTypeMatcher {
 	}
 
 	@Override
-	public boolean matches(String name, Class<?> type) {
+	public boolean matches(String name, Type type) {
 		if (!matches(name) || !matches(type)) {
 			return false;
 		}
@@ -128,7 +130,7 @@ public class GuiceModuleMetadata implements BindingTypeMatcher {
 		return true;
 	}
 
-	private boolean matches(Class<?> type) {
+	private boolean matches(Type type) {
 		if (infrastructureTypes.contains(type)) {
 			return false;
 		}
@@ -140,7 +142,7 @@ public class GuiceModuleMetadata implements BindingTypeMatcher {
 		if (includeFilters != null) {
 			try {
 				MetadataReader reader = metadataReaderFactory.getMetadataReader(type
-						.getName());
+						.getTypeName());
 				for (TypeFilter filter : includeFilters) {
 					if (!filter.match(reader, metadataReaderFactory)) {
 						return false;
@@ -154,7 +156,7 @@ public class GuiceModuleMetadata implements BindingTypeMatcher {
 		if (excludeFilters != null) {
 			try {
 				MetadataReader reader = metadataReaderFactory.getMetadataReader(type
-						.getName());
+						.getTypeName());
 				for (TypeFilter filter : excludeFilters) {
 					if (filter.match(reader, metadataReaderFactory)) {
 						return false;
@@ -168,8 +170,8 @@ public class GuiceModuleMetadata implements BindingTypeMatcher {
 		return true;
 	}
 
-	private boolean visible(Class<?> type) {
-		Class<?> cls = type;
+	private boolean visible(Type type) {
+		Class<?> cls = ResolvableType.forType(type).resolve();
 		while (cls != null && cls != Object.class) {
 			if (!Modifier.isInterface(cls.getModifiers())
 					&& !Modifier.isPublic(cls.getModifiers())

--- a/src/test/java/org/springframework/guice/AbstractCompleteWiringTests.java
+++ b/src/test/java/org/springframework/guice/AbstractCompleteWiringTests.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 
 public abstract class AbstractCompleteWiringTests {
@@ -74,6 +75,12 @@ public abstract class AbstractCompleteWiringTests {
 	public void getNamedInjectedInstance() {
 		assertNotNull(this.injector.getInstance(Thing.class).thang);
 	}
+	
+	@Test
+	public void getParameterizedType() {
+	    Parameterized<String> instance = this.injector.getInstance(Key.get(new TypeLiteral<Parameterized<String>>() {}));
+	    assertNotNull(instance);
+	}
 
 	public interface Service {
 	}
@@ -120,5 +127,8 @@ public abstract class AbstractCompleteWiringTests {
 	}
 
 	public static class Thang {
+	}
+	
+	public static interface Parameterized<T> {
 	}
 }

--- a/src/test/java/org/springframework/guice/GuiceWiringTests.java
+++ b/src/test/java/org/springframework/guice/GuiceWiringTests.java
@@ -18,6 +18,7 @@ import javax.inject.Singleton;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 
 /**
@@ -38,6 +39,7 @@ public class GuiceWiringTests extends AbstractCompleteWiringTests {
 			bind(Service.class).to(MyService.class);
 			bind(Baz.class).in(Singleton.class);
 			bind(Thang.class).annotatedWith(Names.named("thing")).to(Thang.class);
+			bind(new TypeLiteral<Parameterized<String>>(){}).toInstance(new Parameterized<String>(){});
 		}
 	}
 

--- a/src/test/java/org/springframework/guice/annotation/ModuleBeanWiringTests.java
+++ b/src/test/java/org/springframework/guice/annotation/ModuleBeanWiringTests.java
@@ -80,6 +80,11 @@ public class ModuleBeanWiringTests extends AbstractCompleteWiringTests {
 		public Baz baz(Service service) {
 			return new Baz(service);
 		}
+		
+        @Bean
+        public Parameterized<String> parameterizedBean() {
+            return new Parameterized<String>() {};
+        }
 }
 
 	protected static class Spam {

--- a/src/test/java/org/springframework/guice/annotation/ModuleNamedBeanWiringTests.java
+++ b/src/test/java/org/springframework/guice/annotation/ModuleNamedBeanWiringTests.java
@@ -86,6 +86,11 @@ public class ModuleNamedBeanWiringTests extends AbstractCompleteWiringTests {
 		public Baz baz(Service service) {
 			return new Baz(service);
 		}
+		
+        @Bean
+        public Parameterized<String> parameterizedBean() {
+            return new Parameterized<String>() {};
+        }
 }
 
 	protected static class Spam {

--- a/src/test/java/org/springframework/guice/injector/SpringWiringTests.java
+++ b/src/test/java/org/springframework/guice/injector/SpringWiringTests.java
@@ -48,6 +48,10 @@ public class SpringWiringTests extends AbstractCompleteWiringTests {
 		public Thang other() {
 			return new Thang();
 		}
+        @Bean
+        public Parameterized<String> parameterizedBean() {
+            return new Parameterized<String>() {};
+        }
 	}
 
 }

--- a/src/test/java/org/springframework/guice/module/SpringModuleWiringTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleWiringTests.java
@@ -61,7 +61,10 @@ public class SpringModuleWiringTests extends AbstractCompleteWiringTests {
 		public Thing that() {
 			return new Thing();
 		}
-
+		
+		@Bean
+		public Parameterized<String> parameterizedBean() {
+		    return new Parameterized<String>(){};
+		}
 	}
-
 }


### PR DESCRIPTION
attempted fix for issue #14 

My apologies for the `@SuppressWarnings({ "rawtypes", "unchecked" })`. The guice provider binding caused me quite a headache and in the end I couldn't find a "clean" way of maintaining type safety. If you see a better way to go about this, happy to take that implementation instead. 