### PR TITLE
set resource description for beans provided by Guice modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>3.0</version>
+			<version>4.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/springframework/guice/annotation/ModuleRegistryConfiguration.java
+++ b/src/main/java/org/springframework/guice/annotation/ModuleRegistryConfiguration.java
@@ -42,6 +42,7 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.name.Named;
+import com.google.inject.spi.ElementSource;
 
 @Configuration
 @Order(Ordered.HIGHEST_PRECEDENCE + 10)
@@ -61,13 +62,21 @@ public class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostPr
 				continue;
 			}
 
-			entry.getValue().getKey().toString();
+			Binding<?> binding = entry.getValue();
+			Key<?> key = entry.getKey();
+			Object source = binding.getSource();
+
 			RootBeanDefinition bean = new RootBeanDefinition(GuiceFactoryBean.class);
 			ConstructorArgumentValues args = new ConstructorArgumentValues();
-			args.addIndexedArgumentValue(0, entry.getKey().getTypeLiteral().getRawType());
-			args.addIndexedArgumentValue(1, entry.getValue().getProvider());
+			args.addIndexedArgumentValue(0, key.getTypeLiteral().getRawType());
+			args.addIndexedArgumentValue(1, binding.getProvider());
 			bean.setConstructorArgumentValues(args);
-			registry.registerBeanDefinition(extractName(entry.getValue().getKey()), bean);
+			if (source != null && source instanceof ElementSource) {
+				bean.setResourceDescription(((ElementSource) source).getDeclaringSource().toString());
+			} else {
+				bean.setResourceDescription("spring-guice");
+			}
+			registry.registerBeanDefinition(extractName(key), bean);
 		}
 
 		if(injector.getParent() != null)


### PR DESCRIPTION
This one sadly requires updating to Guice 4.0, but the `ElementSource` api gives us a way to tell where a particular binding/bean was defined. The end result here is that Boot users who go to the /beans actuator endpoint can see which `Module` contributed a particular bean. Better feature parity between Spring provided and Guice provided beans.
