### PR TITLE
make GuiceModuleMetadata handle ParameterizedType's correctly #20

### DIFF
--- a/src/main/java/org/springframework/guice/module/GuiceModuleMetadata.java
+++ b/src/main/java/org/springframework/guice/module/GuiceModuleMetadata.java
@@ -18,6 +18,7 @@ package org.springframework.guice.module;
 
 import java.io.IOException;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Set;
@@ -96,7 +97,8 @@ public class GuiceModuleMetadata implements BindingTypeMatcher {
 
 	@Override
 	public boolean matches(String name, Type type) {
-		if (!matches(name) || !matches(type)) {
+		Type rawType = type instanceof ParameterizedType ? ((ParameterizedType)type).getRawType() : type;
+		if (!matches(name) || !matches(rawType)) {
 			return false;
 		}
 		return true;

--- a/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationTests.java
+++ b/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationTests.java
@@ -16,6 +16,9 @@ package org.springframework.guice.annotation;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -125,6 +128,11 @@ public class GuiceModuleAnnotationTests {
 		@Bean
 		public Service service() {
 			return new MyService();
+		}
+		
+		@Bean
+		public Map<String,String> someParameterizedType() {
+			return new HashMap<String,String>();
 		}
 	}
 }


### PR DESCRIPTION
Fix for issue #20 
Seems I introduced a bug when I added support for ParameterizedTypes and just didn't encounter it until I started to use `@GuiceModule` for filtering. Added the data to the existing test case to expose this condition. 