### PR TITLE
Make GuiceModuleRegistrar handle excludeNames filter correctly.

### DIFF
--- a/src/main/java/org/springframework/guice/annotation/GuiceModuleRegistrar.java
+++ b/src/main/java/org/springframework/guice/annotation/GuiceModuleRegistrar.java
@@ -137,7 +137,7 @@ class GuiceModuleRegistrar implements ImportBeanDefinitionRegistrar,
 					.include(
 							includeNames.toArray(new String[includeNames.size()]))
 					.exclude(
-							excludeNames.toArray(new Pattern[excludeNames.size()]));
+							excludeNames.toArray(new String[excludeNames.size()]));
 		}
 
 		@Override

--- a/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationTests.java
+++ b/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationTests.java
@@ -68,6 +68,18 @@ public class GuiceModuleAnnotationTests {
 		assertNull(injector.getInstance(Service.class));
 	}
 
+	@Test(expected = ConfigurationException.class)
+	public void excludesNames() throws Exception {
+		Injector injector = createInjector(TestConfig.class, MetadataExcludeNamesConfig.class);
+		injector.getBinding(Service.class);
+	}
+
+	@Test(expected = ConfigurationException.class)
+	public void excludesPatterns() throws Exception {
+		Injector injector = createInjector(TestConfig.class, MetadataExcludePatternsConfig.class);
+		injector.getBinding(Service.class);
+	}
+
 	@Test
 	public void twoIncludes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataIncludesConfig.class, MetadataMoreIncludesConfig.class);
@@ -99,8 +111,13 @@ public class GuiceModuleAnnotationTests {
 	}
 
 	@Configuration
+	@GuiceModule(excludeNames="*")
+	protected static class MetadataExcludeNamesConfig {
+	}
+
+	@Configuration
 	@GuiceModule(excludePatterns=".*")
-	protected static class MetadataExcludesNameConfig {
+	protected static class MetadataExcludePatternsConfig {
 	}
 
 	@Configuration


### PR DESCRIPTION
This fixes #24 by correcting the source line mentioned in that issue and adding a unit test for it.