### PR TITLE
remove check for Tool stage from SpringModule 

### DIFF
--- a/src/main/java/org/springframework/guice/module/SpringModule.java
+++ b/src/main/java/org/springframework/guice/module/SpringModule.java
@@ -72,24 +72,22 @@ public class SpringModule extends AbstractModule {
 
 	@Override
 	public void configure() {
-		if (binder().currentStage() != Stage.TOOL) {
-			if (beanFactory == null) {
-				beanFactory = beanFactoryProvider.get();
-			}
-			if (beanFactory.getBeanNamesForType(ProvisionListener.class).length > 0) {
-				binder().bindListener(Matchers.any(),
-						beanFactory.getBeansOfType(ProvisionListener.class).values()
-								.toArray(new ProvisionListener[0]));
-			}
-			if (beanFactory instanceof DefaultListableBeanFactory) {
-				((DefaultListableBeanFactory) beanFactory)
-						.setAutowireCandidateResolver(new GuiceAutowireCandidateResolver(
-								binder().getProvider(Injector.class)));
-			}
-			if (beanFactory.getBeanNamesForType(GuiceModuleMetadata.class).length > 0) {
-				this.matcher = new CompositeTypeMatcher(
-						beanFactory.getBeansOfType(GuiceModuleMetadata.class).values());
-			}
+		if (beanFactory == null) {
+			beanFactory = beanFactoryProvider.get();
+		}
+		if (beanFactory.getBeanNamesForType(ProvisionListener.class).length > 0) {
+			binder().bindListener(Matchers.any(),
+					beanFactory.getBeansOfType(ProvisionListener.class).values()
+							.toArray(new ProvisionListener[0]));
+		}
+		if (beanFactory instanceof DefaultListableBeanFactory) {
+			((DefaultListableBeanFactory) beanFactory)
+					.setAutowireCandidateResolver(new GuiceAutowireCandidateResolver(
+							binder().getProvider(Injector.class)));
+		}
+		if (beanFactory.getBeanNamesForType(GuiceModuleMetadata.class).length > 0) {
+			this.matcher = new CompositeTypeMatcher(
+					beanFactory.getBeansOfType(GuiceModuleMetadata.class).values());
 		}
 		bind(beanFactory);
 	}

--- a/src/test/java/org/springframework/guice/annotation/EnableGuiceModulesTests.java
+++ b/src/test/java/org/springframework/guice/annotation/EnableGuiceModulesTests.java
@@ -19,6 +19,7 @@ import javax.inject.Named;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 
+import org.junit.After;
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,8 +37,22 @@ import static org.junit.Assert.assertNotNull;
  */
 public class EnableGuiceModulesTests {
 
+	@After
+	public void cleanUp() {
+		System.clearProperty("spring.guice.dedup");
+	}
+	
 	@Test
 	public void test() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				TestConfig.class);
+		assertNotNull(context.getBean(Foo.class));
+		context.close();
+	}
+	
+	@Test
+	public void testWithDedupFeatureEnabled() {
+		System.setProperty("spring.guice.dedup", "true");
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 				TestConfig.class);
 		assertNotNull(context.getBean(Foo.class));


### PR DESCRIPTION
Fix for #35 
This check is no longer required now that we support multiple stages. It was causing `@GuiceModule` filters to not be applied. 