### PR TITLE
Fix #44 Support multiple Named bindings of same type

### DIFF
--- a/src/main/java/org/springframework/guice/injector/SpringInjector.java
+++ b/src/main/java/org/springframework/guice/injector/SpringInjector.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ApplicationContext;
@@ -128,8 +129,12 @@ public class SpringInjector implements Injector {
 		@SuppressWarnings("unchecked")
 		final Class<T> cls = (Class<T>) type;
 		return new Provider<T>() {
+			@SuppressWarnings("unchecked")
 			@Override
 			public T get() {
+				if(key.getAnnotation() != null) {
+					return (T) BeanFactoryAnnotationUtils.qualifiedBeanOfType(SpringInjector.this.beanFactory, type, name);
+				}
 				return SpringInjector.this.beanFactory.getBean(cls);
 			}
 		};

--- a/src/test/java/org/springframework/guice/BindingAnnotationTests.java
+++ b/src/test/java/org/springframework/guice/BindingAnnotationTests.java
@@ -47,9 +47,15 @@ public class BindingAnnotationTests {
 		SomeDependencyWithNamedAnnotationOnProvider someDependencyWithNamedAnnotationOnProvider = injector.getInstance(Key.get(SomeDependencyWithNamedAnnotationOnProvider.class, Names.named("javaxNamed")));
 		assertNotNull(someDependencyWithNamedAnnotationOnProvider);
 		
+		SomeDependencyWithNamedAnnotationOnProvider someSecondDependencyWithNamedAnnotationOnProvider = injector.getInstance(Key.get(SomeDependencyWithNamedAnnotationOnProvider.class, Names.named("javaxNamed2")));
+		assertNotNull(someSecondDependencyWithNamedAnnotationOnProvider);
+		
 		//Check Guice @Named
 		SomeDependencyWithGuiceNamedAnnotationOnProvider someDependencyWithGuiceNamedAnnotationOnProvider = injector.getInstance(Key.get(SomeDependencyWithGuiceNamedAnnotationOnProvider.class, Names.named("guiceNamed")));
 		assertNotNull(someDependencyWithGuiceNamedAnnotationOnProvider);
+		
+		SomeDependencyWithGuiceNamedAnnotationOnProvider someSecondDependencyWithGuiceNamedAnnotationOnProvider = injector.getInstance(Key.get(SomeDependencyWithGuiceNamedAnnotationOnProvider.class, Names.named("guiceNamed2")));
+		assertNotNull(someSecondDependencyWithGuiceNamedAnnotationOnProvider);
 		
 		//Check @Qualifier with Interface
 		SomeInterface someInterface = injector.getInstance(Key.get(SomeInterface.class, SomeQualifierAnnotation.class));
@@ -100,9 +106,21 @@ class BindingAnnotationTestsConfig {
 		return new SomeDependencyWithNamedAnnotationOnProvider();
 	}
 	
+	@Bean(name="javaxNamed2")
+	@Named("javaxNamed2")
+	public SomeDependencyWithNamedAnnotationOnProvider someSecondDependencyWithNamedAnnotationOnProvider() {
+		return new SomeDependencyWithNamedAnnotationOnProvider();
+	}
+	
 	@Bean
 	@com.google.inject.name.Named("guiceNamed")
 	public SomeDependencyWithGuiceNamedAnnotationOnProvider someDependencyWithGuiceNamedAnnotationOnProvider() {
+		return new SomeDependencyWithGuiceNamedAnnotationOnProvider();
+	}
+	
+	@Bean
+	@com.google.inject.name.Named("guiceNamed2")
+	public SomeDependencyWithGuiceNamedAnnotationOnProvider someSecondDependencyWithGuiceNamedAnnotationOnProvider() {
 		return new SomeDependencyWithGuiceNamedAnnotationOnProvider();
 	}
 	

--- a/src/test/java/org/springframework/guice/BindingAnnotationTests.java
+++ b/src/test/java/org/springframework/guice/BindingAnnotationTests.java
@@ -20,6 +20,8 @@ import org.springframework.guice.BindingAnnotationTests.SomeDependencyWithNamedA
 import org.springframework.guice.BindingAnnotationTests.SomeDependencyWithQualifierOnProvider;
 import org.springframework.guice.BindingAnnotationTests.SomeDependencyWithQualifierOnProviderWhichImplementsSomeInterface;
 import org.springframework.guice.BindingAnnotationTests.SomeInterface;
+import org.springframework.guice.BindingAnnotationTests.SomeNamedDepWithType1;
+import org.springframework.guice.BindingAnnotationTests.SomeNamedDepWithType2;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
 import com.google.inject.BindingAnnotation;
@@ -61,6 +63,12 @@ public class BindingAnnotationTests {
 		SomeInterface someInterface = injector.getInstance(Key.get(SomeInterface.class, SomeQualifierAnnotation.class));
 		assertNotNull(someInterface);
 		
+		//Check different types with same @Named
+		assertNotNull(injector.getInstance(SomeNamedDepWithType1.class));
+		assertNotNull(injector.getInstance(SomeNamedDepWithType2.class));
+		
+		assertNotNull(injector.getInstance(Key.get(SomeNamedDepWithType1.class, Names.named("sameNameDifferentType"))));
+		assertNotNull(injector.getInstance(Key.get(SomeNamedDepWithType2.class, Names.named("sameNameDifferentType"))));
 		context.close();
 	}
 	
@@ -71,6 +79,8 @@ public class BindingAnnotationTests {
 	public static class SomeDependencyWithGuiceNamedAnnotationOnProvider {}
 	public static interface SomeInterface{}
 	public static class SomeDependencyWithQualifierOnProviderWhichImplementsSomeInterface implements SomeInterface {}
+	public static class SomeNamedDepWithType1 {} 
+	public static class SomeNamedDepWithType2 {} 
 }
 
 @Qualifier
@@ -128,5 +138,17 @@ class BindingAnnotationTestsConfig {
 	@SomeQualifierAnnotation
 	public SomeInterface someInterface() {
 		return new SomeDependencyWithQualifierOnProviderWhichImplementsSomeInterface();
+	}
+	
+	@Bean
+	@Named("sameNameDifferentType")
+	public SomeNamedDepWithType1 someNamedDepWithType1() {
+		return new SomeNamedDepWithType1();
+	}
+	
+	@Bean
+	@Named("sameNameDifferentType")
+	public SomeNamedDepWithType2 someNamedDepWithType2() {
+		return new SomeNamedDepWithType2();
 	}
 }

--- a/src/test/java/org/springframework/guice/DuplicateNamesDifferentTypesTests.java
+++ b/src/test/java/org/springframework/guice/DuplicateNamesDifferentTypesTests.java
@@ -1,0 +1,94 @@
+package org.springframework.guice;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.guice.DuplicateNamesDifferentTypesTests.SomeJavaxNamedDepWithType1;
+import org.springframework.guice.DuplicateNamesDifferentTypesTests.SomeJavaxNamedDepWithType2;
+import org.springframework.guice.DuplicateNamesDifferentTypesTests.SomeNamedDepWithType1;
+import org.springframework.guice.DuplicateNamesDifferentTypesTests.SomeNamedDepWithType2;
+import org.springframework.guice.annotation.EnableGuiceModules;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+
+public class DuplicateNamesDifferentTypesTests {
+
+	@Test
+	public void verifyNoDuplicateBindingErrorWhenDedupeEnabled() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				DuplicateNamesDifferentTypesTestsConfig.class);
+
+		//Check Guice @Named
+		assertNotNull(context.getBean(SomeNamedDepWithType1.class));
+		assertNotNull(context.getBean(SomeNamedDepWithType2.class));
+		assertNotNull(BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(), SomeNamedDepWithType1.class, "sameNameDifferentType"));
+		
+		//Check javax @Named
+		assertNotNull(context.getBean(SomeJavaxNamedDepWithType1.class));
+		assertNotNull(context.getBean(SomeJavaxNamedDepWithType2.class));
+		assertNotNull(BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(), SomeJavaxNamedDepWithType1.class, "sameJavaxName"));
+		context.getBeansOfType(SomeJavaxNamedDepWithType1.class);
+		
+		context.close();
+	}
+
+	public static class SomeNamedDepWithType1 {}
+	public static class SomeNamedDepWithType2 {}
+	public static class SomeJavaxNamedDepWithType1 {}
+	public static class SomeJavaxNamedDepWithType2 {}
+	
+	public static class SomeClassWithDeps{
+		@Autowired
+		@Qualifier("sameJavaxName2") 
+		SomeJavaxNamedDepWithType1 qualified;
+		
+		@Autowired
+		@Named("sameJavaxName2") 
+		SomeJavaxNamedDepWithType1 named;
+		
+		@Autowired
+		@javax.inject.Named("sameJavaxName2") 
+		SomeJavaxNamedDepWithType1 javaxNamed;
+	}
+}
+
+@EnableGuiceModules
+@Configuration
+class DuplicateNamesDifferentTypesTestsConfig {
+
+	@Bean
+	public Module module() {
+		return new AbstractModule() {
+			@Override
+			protected void configure() {
+				bind(SomeNamedDepWithType1.class).annotatedWith(Names.named("sameNameDifferentType"))
+						.to(SomeNamedDepWithType1.class);
+				bind(SomeNamedDepWithType2.class).annotatedWith(Names.named("sameNameDifferentType"))
+						.to(SomeNamedDepWithType2.class);
+			}
+			
+			@Provides 
+			@Named("sameJavaxName") 
+			public SomeJavaxNamedDepWithType1 someJavaxNamedDepWithType1() {
+				return new SomeJavaxNamedDepWithType1();
+			}
+			
+			
+			@Provides 
+			@Named("sameJavaxName") 
+			public SomeJavaxNamedDepWithType2 someJavaxNamedDepWithType2() {
+				return new SomeJavaxNamedDepWithType2();
+			}
+		};
+	}	
+}

--- a/src/test/java/org/springframework/guice/PrivateModuleTests.java
+++ b/src/test/java/org/springframework/guice/PrivateModuleTests.java
@@ -7,6 +7,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,7 +46,8 @@ public class PrivateModuleTests {
 		assertNotNull(injectorProvidedPrivateBinding);
 		SomeInterface springProvidedPrivateBinding = context.getBean(SomeInterface.class);
 		assertNotNull(springProvidedPrivateBinding);
-		SomeInterface namedPrivateBinding = context.getBean("exposed",SomeInterface.class);
+		SomeInterface namedPrivateBinding = BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(),
+				SomeInterface.class, "exposed");
 		assertNotNull(namedPrivateBinding);
 		assertEquals(injectorProvidedPrivateBinding, springProvidedPrivateBinding);
 		assertEquals(injectorProvidedPrivateBinding, namedPrivateBinding);
@@ -63,6 +65,11 @@ public class PrivateModuleTests {
 	@Test(expected=NoSuchBeanDefinitionException.class)
 	public void verifyPrivateModulesPrivateBindingsAreNotExposedViaSpring() {
 		context.getBean("notexposed",SomeInterface.class);
+	}
+	
+	@Test(expected = NoSuchBeanDefinitionException.class)
+	public void verifyPrivateModulesPrivateBindingsAreNotExposedViaSpringWithQualifier() {
+		BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(), SomeInterface.class, "notexposed");
 	}
 
 	public static interface SomeInterface {}


### PR DESCRIPTION
Fixes issue #44
use Key<?> for binding dedupe check in SpringModule to include annotations

fix issues where @Named was not considered when fetching beans of the same type