### PR TITLE
Set Binding Factory bean's LazyInit if Injector stage is Development

### DIFF
--- a/src/test/java/org/springframework/guice/module/DevelepmentStageInjectorTest.java
+++ b/src/test/java/org/springframework/guice/module/DevelepmentStageInjectorTest.java
@@ -14,6 +14,7 @@ import org.springframework.guice.annotation.InjectorFactory;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DevelepmentStageInjectorTest {
 
@@ -32,6 +33,8 @@ public class DevelepmentStageInjectorTest {
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(DevelepmentStageInjectorTest.ModulesConfig.class);
         TestGuiceModule testGuiceModule = context.getBean(TestGuiceModule.class);
         assertFalse(testGuiceModule.getProviderExecuted());
+        GuiceToken guiceToken = context.getBean(GuiceToken.class);
+        assertTrue(testGuiceModule.getProviderExecuted());
         context.close();
     }
 

--- a/src/test/java/org/springframework/guice/module/DevelepmentStageInjectorTest.java
+++ b/src/test/java/org/springframework/guice/module/DevelepmentStageInjectorTest.java
@@ -1,0 +1,81 @@
+package org.springframework.guice.module;
+
+import com.google.inject.*;
+import com.google.inject.Module;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.guice.annotation.EnableGuiceModules;
+import org.springframework.guice.annotation.InjectorFactory;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+
+public class DevelepmentStageInjectorTest {
+
+    @BeforeClass
+    public static void init() {
+        System.setProperty("spring.guice.stage", "DEVELOPMENT");
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        System.clearProperty("spring.guice.stage");
+    }
+
+    @Test
+    public void testLazyInitBean() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(DevelepmentStageInjectorTest.ModulesConfig.class);
+        TestGuiceModule testGuiceModule = context.getBean(TestGuiceModule.class);
+        assertFalse(testGuiceModule.getProviderExecuted());
+        context.close();
+    }
+
+    @Configuration
+    @EnableGuiceModules
+    static class ModulesConfig {
+        @Bean
+        public TestGuiceModule testGuiceModule() {
+            return new TestGuiceModule();
+        }
+
+        @Bean
+        public InjectorFactory injectorFactory() {
+            return new TestDevelopmentStageInjectorFactory();
+        }
+
+    }
+
+    static class TestGuiceModule extends AbstractModule {
+        private boolean providerExecuted = false;
+
+        public boolean getProviderExecuted() {
+            return this.providerExecuted;
+        }
+
+        @Override
+        protected void configure() {
+        }
+
+        @Provides
+        @Singleton
+        public GuiceToken guiceToken() {
+            this.providerExecuted = true;
+            return new GuiceToken();
+        }
+    }
+
+    static class TestDevelopmentStageInjectorFactory implements InjectorFactory {
+
+        @Override
+        public Injector createInjector(List<Module> modules) {
+            return Guice.createInjector(Stage.DEVELOPMENT, modules);
+        }
+    }
+
+    static class GuiceToken {}
+}


### PR DESCRIPTION
Currently, Netflix's Guice framework sets the Injector stage as "DEVELOPMENT" so everything is lazy. This PR is to make it consistent between SpringBoot's factory bean and Guice's Injector stage so SpringBoot doesn't instantiate bindings as factory beans if the bindings are not referenced. 