### PR TITLE
Delay injector creation until after registerBeanPostProcessors() phase

### DIFF
--- a/src/test/java/org/springframework/guice/BeanPostProcessorTests.java
+++ b/src/test/java/org/springframework/guice/BeanPostProcessorTests.java
@@ -87,7 +87,7 @@ class BeanPostProcessorTestConfig {
 		
 	}
 	
-	public static class TestBeanPostProcessor implements BeanPostProcessor, Ordered {
+	public static class TestBeanPostProcessor implements BeanPostProcessor {
 		@Override
 		public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
 			if(bean instanceof PostProcessedBean) {
@@ -99,11 +99,6 @@ class BeanPostProcessorTestConfig {
 		@Override
 		public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 			return bean;
-		}
-
-		@Override
-		public int getOrder() {
-			return 0;
 		}
 	}
 

--- a/src/test/java/org/springframework/guice/BindingDeduplicationTests.java
+++ b/src/test/java/org/springframework/guice/BindingDeduplicationTests.java
@@ -1,12 +1,12 @@
 package org.springframework.guice;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.CreationException;
 import com.google.inject.Module;
 
 import com.google.inject.multibindings.OptionalBinder;
 import org.junit.AfterClass;
 import org.junit.Test;
-import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,7 +35,7 @@ public class BindingDeduplicationTests {
 		context.close();
 	}
 
-	@Test(expected = BeanCreationException.class)
+	@Test(expected = CreationException.class)
 	public void verifyDuplicateBindingErrorWhenDedupeNotEnabled() {
 		System.setProperty("spring.guice.dedup", "false");
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(

--- a/src/test/java/org/springframework/guice/InjectorFactoryTests.java
+++ b/src/test/java/org/springframework/guice/InjectorFactoryTests.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.ApplicationContextException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,7 +32,7 @@ public class InjectorFactoryTests {
 		context.close();
 	}
 
-	@Test(expected = BeanCreationException.class)
+	@Test(expected = ApplicationContextException.class)
 	public void testMultipleInjectorFactoriesThrowsApplicationContextException() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(InjectorFactoryConfig.class,
 				SecondInjectorFactoryConfig.class, ModulesConfig.class);


### PR DESCRIPTION
The current implementation uses a dedicated **Ordered** [BPP](https://github.com/spring-projects/spring-guice/blob/master/src/main/java/org/springframework/guice/annotation/ModuleRegistryConfiguration.java#L332) that creates the injector the first time `postProcessAfterInitialization` is called. Since the BPP is ordered, any non-ordered BPP beans are created afterwards, thus this ordered BPP also applies to them and the injector will be created when the first of them is being initialized.
This effectively causes all Guice bindings and their bean dependencies to initialize in the `registerBeanPostProcessors` phase, specifically when the non-ordered BPPs are being created. That also means that the non-ordered BPPs will not apply to all the Guice bindings and their bean dependencies because they weren't registered yet in the bean factory.

This change makes the BPP (that creates the injector) **non-ordered** which affectively delays when it is registered in the bean factory, and causes the injector to be created when the first bean (non BPP) is created. For servlet based application contexts, that happens as part of onRefresh(). 
This change also publishes an event to make sure the injector isn't created too late, which may cause circular dependency errors. Combining both approaches (post-processor and the event publishing) ensure the injector is created after the `registerBeanPostProcessors` phase but before the first created bean or during `registerListeners` phase.