### PR TITLE
Upgrade to Guice 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,8 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>4.1.0</version>
+			<version>4.2.3</version>
 			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.google.inject.extensions</groupId>
-			<artifactId>guice-multibindings</artifactId>
-			<version>4.1.0</version>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>4.2.3</version>
+			<version>5.1.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/springframework/guice/injector/SpringInjector.java
+++ b/src/main/java/org/springframework/guice/injector/SpringInjector.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.inject.spi.Element;
+import com.google.inject.spi.InjectionPoint;
 import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
@@ -187,6 +189,16 @@ public class SpringInjector implements Injector {
 
 	@Override
 	public Set<TypeConverterBinding> getTypeConverterBindings() {
+		return null;
+	}
+
+	@Override
+	public List<Element> getElements() {
+		return null;
+	}
+
+	@Override
+	public Map<TypeLiteral<?>, List<InjectionPoint>> getAllMembersInjectorInjectionPoints() {
 		return null;
 	}
 


### PR DESCRIPTION
PR for #91 

This upgrades the default Guice version to 5.1.0 to prepare to better support Java 17. Overall it seems like a pretty straightforward upgrade, but the additional required methods added to the `Injector` interface means this should probably require a new major release of spring-guice. 

Check out the Guice release notes for context:

* [Guice 4.2.0](https://github.com/google/guice/wiki/Guice42)
* [Guice 4.2.1](https://github.com/google/guice/wiki/Guice421)
* [Guice 4.2.2](https://github.com/google/guice/wiki/Guice422)
* [Guice 4.2.0](https://github.com/google/guice/wiki/Guice423)
* [Guice 5.0.1](https://github.com/google/guice/wiki/Guice501)
* [Guice 5.1.0](https://github.com/google/guice/wiki/Guice510)

With this I tried compiling and testing locally with Java 17, but looks like we'll need to upgrade Spring and probably Mockito. I can create a ticket to track Java 17 support separately