### PR TITLE
Upgrade Spring to 5.3.16, and Mockito to 4.3.1

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -85,7 +85,7 @@ jobs:
         - |
           rm -rf ~/.m2
           ln -s $(pwd)/.m2 ~/.m2
-          ./mvnw install -Dspring.version=5.1.2.RELEASE
+          ./mvnw install -Dspring.version=5.3.16
 - name: deploy
   plan:
   - get: source

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<spring.version>5.1.18.RELEASE</spring.version>
+		<spring.version>5.3.16</spring.version>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -48,13 +48,13 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.10.19</version>
+			<version>4.3.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/test/java/org/springframework/guice/InjectorFactoryTests.java
+++ b/src/test/java/org/springframework/guice/InjectorFactoryTests.java
@@ -20,7 +20,7 @@ public class InjectorFactoryTests {
 
 	@Before
 	public void init() {
-		Mockito.when(injectorFactory.createInjector(Mockito.anyListOf(Module.class)))
+		Mockito.when(injectorFactory.createInjector(Mockito.anyList()))
 				.thenReturn(Guice.createInjector());
 	}
 
@@ -28,7 +28,7 @@ public class InjectorFactoryTests {
 	public void testCustomInjectorIsCreated() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(InjectorFactoryConfig.class,
 				ModulesConfig.class);
-		Mockito.verify(injectorFactory, Mockito.times(1)).createInjector(Mockito.anyListOf(Module.class));
+		Mockito.verify(injectorFactory, Mockito.times(1)).createInjector(Mockito.anyList());
 		context.close();
 	}
 


### PR DESCRIPTION
Required for #93 

This PR upgrades to the latest Spring version, and Mockito, both of which are needed to support Java 17. 

When combined with #91, this gets me closer to compile and test locally with Java 17. So these two PRs are probably worth a new minor or major version bump of spring-guice