### PR TITLE
Use explicit maven plugin versions to reduce some maven warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
@@ -95,6 +96,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>javadoc</id>
@@ -107,6 +109,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>


### PR DESCRIPTION
Before this PR when running any `./mvnw clean install` command, maven would warn with messages like this:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.springframework.guice:spring-guice:jar:2.0.0.BUILD-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 74, column 12
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ line 108, column 12
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ line 96, column 12
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

This PR sets explicit versions of some maven plugins to quiet down those warnings. I set them to the versions of the plugins that Maven was already using according to the build output. Now when running `./mvnw clean install` Maven doesn't log any warnings about this anymore.