### PR TITLE
Upgrade to JUnit 5 and convert assertions to AssertJ 

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -3,10 +3,7 @@
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
         "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="com.puppycrawl.tools.checkstyle.Checker">
-    <module name="io.spring.javaformat.checkstyle.SpringChecks" >
-		<!-- Exclude some rules that require assertJ-->
-		<property name="excludes" value="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck" />
-	</module>
+    <module name="io.spring.javaformat.checkstyle.SpringChecks" />
 
 	<!-- Enable @SuppressWarnings -->
 	<module name="TreeWalker">

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="com.puppycrawl.tools.checkstyle.Checker">
+    <module name="io.spring.javaformat.checkstyle.SpringChecks" >
+		<!-- Exclude some rules that require assertJ-->
+		<property name="excludes" value="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck" />
+	</module>
+
+	<!-- Enable @SuppressWarnings -->
+	<module name="TreeWalker">
+		<module name="SuppressWarningsHolder"/>
+	</module>
+	<module name="SuppressWarningsFilter"/>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.8.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.8.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-suite-engine</artifactId>
+			<version>1.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -82,7 +94,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.22.2</version>
 				<configuration>
 					<!--forkMode>pertest</forkMode -->
 					<includes>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.22.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>4.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,37 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.1.1</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>8.45.1</version>
+					</dependency>
+					<dependency>
+						<groupId>io.spring.javaformat</groupId>
+						<artifactId>spring-javaformat-checkstyle</artifactId>
+						<version>0.0.31</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>checkstyle-validation</id>
+						<phase>validate</phase>
+						<inherited>true</inherited>
+						<configuration>
+							<configLocation>config/checkstyle/checkstyle.xml</configLocation>
+							<includeTestSourceDirectory>true</includeTestSourceDirectory>
+						</configuration>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/org/springframework/guice/annotation/EnableGuiceModules.java
+++ b/src/main/java/org/springframework/guice/annotation/EnableGuiceModules.java
@@ -1,14 +1,17 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.annotation;
@@ -19,14 +22,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.context.annotation.Import;
-
 import com.google.inject.Module;
+
+import org.springframework.context.annotation.Import;
 
 /**
  * Enable spring beans that are themselves a Guice {@link Module} to contribute
  * dependencies via the bindings in Guice.
- * 
+ *
  * @author Dave Syer
  *
  */

--- a/src/main/java/org/springframework/guice/annotation/GuiceFactoryBean.java
+++ b/src/main/java/org/springframework/guice/annotation/GuiceFactoryBean.java
@@ -1,28 +1,33 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.springframework.guice.annotation;
 
 import javax.inject.Provider;
 
-import org.springframework.beans.factory.FactoryBean;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.google.inject.Injector;
 import com.google.inject.Key;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Convenience class used to map a Guice {@link Provider} to a Spring bean.
  *
+ * @param <T> the bean type
  * @author Dave Syer
  */
 class GuiceFactoryBean<T> implements FactoryBean<T> {
@@ -36,7 +41,7 @@ class GuiceFactoryBean<T> implements FactoryBean<T> {
 	@Autowired
 	private Injector injector;
 
-	public GuiceFactoryBean(Class<T> beanType, Key<T> key, boolean isSingleton) {
+	GuiceFactoryBean(Class<T> beanType, Key<T> key, boolean isSingleton) {
 		this.beanType = beanType;
 		this.key = key;
 		this.isSingleton = isSingleton;
@@ -44,12 +49,12 @@ class GuiceFactoryBean<T> implements FactoryBean<T> {
 
 	@Override
 	public T getObject() throws Exception {
-		return (T) injector.getInstance(key);
+		return (T) this.injector.getInstance(this.key);
 	}
 
 	@Override
 	public Class<?> getObjectType() {
-		return beanType;
+		return this.beanType;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/guice/annotation/GuiceModule.java
+++ b/src/main/java/org/springframework/guice/annotation/GuiceModule.java
@@ -1,14 +1,17 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.annotation;
@@ -44,7 +47,7 @@ import org.springframework.guice.module.SpringModule;
 public @interface GuiceModule {
 
 	/**
-	 * Specifies which types are eligible for inclusion in Guice module
+	 * Specifies which types are eligible for inclusion in Guice module.
 	 * @return filters for inclusion
 	 */
 	Filter[] includeFilters() default {};
@@ -56,7 +59,7 @@ public @interface GuiceModule {
 	Filter[] excludeFilters() default {};
 
 	/**
-	 * Specifies which names (by regex) are eligible for inclusion in Guice module
+	 * Specifies which names (by regex) are eligible for inclusion in Guice module.
 	 * @return regexes
 	 */
 	String[] includePatterns() default {};
@@ -70,7 +73,7 @@ public @interface GuiceModule {
 
 	/**
 	 * Specifies which names (by simple wildcard match) are eligible for inclusion in
-	 * Guice module
+	 * Guice module.
 	 * @return bean names
 	 */
 	String[] includeNames() default {};

--- a/src/main/java/org/springframework/guice/annotation/GuiceModuleRegistrar.java
+++ b/src/main/java/org/springframework/guice/annotation/GuiceModuleRegistrar.java
@@ -74,66 +74,6 @@ class GuiceModuleRegistrar implements ImportBeanDefinitionRegistrar, ResourceLoa
 		registry.registerBeanDefinition(name, definition);
 	}
 
-	protected static class GuiceModuleMetadataFactory implements FactoryBean<GuiceModuleMetadata> {
-
-		private Collection<? extends TypeFilter> includeFilters;
-
-		private Collection<? extends TypeFilter> excludeFilters;
-
-		private Collection<Pattern> includePatterns;
-
-		private Collection<Pattern> excludePatterns;
-
-		private Collection<String> includeNames;
-
-		private Collection<String> excludeNames;
-
-		public void setIncludeFilters(Collection<? extends TypeFilter> includeFilters) {
-			this.includeFilters = includeFilters;
-		}
-
-		public void setExcludeFilters(Collection<? extends TypeFilter> excludeFilters) {
-			this.excludeFilters = excludeFilters;
-		}
-
-		public void setIncludePatterns(Collection<Pattern> includePatterns) {
-			this.includePatterns = includePatterns;
-		}
-
-		public void setExcludePatterns(Collection<Pattern> excludePatterns) {
-			this.excludePatterns = excludePatterns;
-		}
-
-		public void setIncludeNames(Collection<String> includeNames) {
-			this.includeNames = includeNames;
-		}
-
-		public void setExcludeNames(Collection<String> excludeNames) {
-			this.excludeNames = excludeNames;
-		}
-
-		@Override
-		public GuiceModuleMetadata getObject() throws Exception {
-			return new GuiceModuleMetadata().include(includeFilters.toArray(new TypeFilter[includeFilters.size()]))
-					.exclude(excludeFilters.toArray(new TypeFilter[excludeFilters.size()]))
-					.include(includePatterns.toArray(new Pattern[includePatterns.size()]))
-					.exclude(excludePatterns.toArray(new Pattern[excludePatterns.size()]))
-					.include(includeNames.toArray(new String[includeNames.size()]))
-					.exclude(excludeNames.toArray(new String[excludeNames.size()]));
-		}
-
-		@Override
-		public Class<?> getObjectType() {
-			return GuiceModuleMetadata.class;
-		}
-
-		@Override
-		public boolean isSingleton() {
-			return false;
-		}
-
-	}
-
 	private Set<Pattern> parsePatterns(AnnotationMetadata annotation, String attributeName) {
 		Set<Pattern> result = new HashSet<Pattern>();
 		AnnotationAttributes attributes = new AnnotationAttributes(
@@ -224,9 +164,70 @@ class GuiceModuleRegistrar implements ImportBeanDefinitionRegistrar, ResourceLoa
 		try {
 			return filterAttributes.getStringArray("pattern");
 		}
-		catch (IllegalArgumentException o_O) {
+		catch (IllegalArgumentException ex) {
 			return new String[0];
 		}
+	}
+
+	protected static class GuiceModuleMetadataFactory implements FactoryBean<GuiceModuleMetadata> {
+
+		private Collection<? extends TypeFilter> includeFilters;
+
+		private Collection<? extends TypeFilter> excludeFilters;
+
+		private Collection<Pattern> includePatterns;
+
+		private Collection<Pattern> excludePatterns;
+
+		private Collection<String> includeNames;
+
+		private Collection<String> excludeNames;
+
+		public void setIncludeFilters(Collection<? extends TypeFilter> includeFilters) {
+			this.includeFilters = includeFilters;
+		}
+
+		public void setExcludeFilters(Collection<? extends TypeFilter> excludeFilters) {
+			this.excludeFilters = excludeFilters;
+		}
+
+		public void setIncludePatterns(Collection<Pattern> includePatterns) {
+			this.includePatterns = includePatterns;
+		}
+
+		public void setExcludePatterns(Collection<Pattern> excludePatterns) {
+			this.excludePatterns = excludePatterns;
+		}
+
+		public void setIncludeNames(Collection<String> includeNames) {
+			this.includeNames = includeNames;
+		}
+
+		public void setExcludeNames(Collection<String> excludeNames) {
+			this.excludeNames = excludeNames;
+		}
+
+		@Override
+		public GuiceModuleMetadata getObject() throws Exception {
+			return new GuiceModuleMetadata()
+					.include(this.includeFilters.toArray(new TypeFilter[this.includeFilters.size()]))
+					.exclude(this.excludeFilters.toArray(new TypeFilter[this.excludeFilters.size()]))
+					.include(this.includePatterns.toArray(new Pattern[this.includePatterns.size()]))
+					.exclude(this.excludePatterns.toArray(new Pattern[this.excludePatterns.size()]))
+					.include(this.includeNames.toArray(new String[this.includeNames.size()]))
+					.exclude(this.excludeNames.toArray(new String[this.excludeNames.size()]));
+		}
+
+		@Override
+		public Class<?> getObjectType() {
+			return GuiceModuleMetadata.class;
+		}
+
+		@Override
+		public boolean isSingleton() {
+			return false;
+		}
+
 	}
 
 }

--- a/src/main/java/org/springframework/guice/annotation/InjectorFactory.java
+++ b/src/main/java/org/springframework/guice/annotation/InjectorFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice.annotation;
 
 import java.util.List;
@@ -8,9 +24,12 @@ import com.google.inject.Module;
 /***
  * Factory which allows for custom creation of the Guice Injector to be used in
  * the @{@link EnableGuiceModules} feature.
+ *
+ * @author Dave Syer
+ * @author Taylor Wicksell
  */
 public interface InjectorFactory {
 
-	public Injector createInjector(List<Module> modules);
+	Injector createInjector(List<Module> modules);
 
 }

--- a/src/main/java/org/springframework/guice/annotation/ModuleRegistryConfiguration.java
+++ b/src/main/java/org/springframework/guice/annotation/ModuleRegistryConfiguration.java
@@ -1,17 +1,32 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.annotation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import com.google.inject.Binding;
 import com.google.inject.Guice;
@@ -21,9 +36,14 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.Stage;
 import com.google.inject.name.Named;
-import com.google.inject.spi.*;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.ElementSource;
+import com.google.inject.spi.Elements;
+import com.google.inject.spi.LinkedKeyBinding;
+import com.google.inject.spi.PrivateElements;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -46,18 +66,6 @@ import org.springframework.core.Ordered;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.Order;
 import org.springframework.guice.module.SpringModule;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 /**
  * Configuration postprocessor that registers all the bindings in Guice modules as Spring
@@ -95,18 +103,18 @@ class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor
 	public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
 		List<Module> modules = new ArrayList<>(
 				((ConfigurableListableBeanFactory) registry).getBeansOfType(Module.class).values());
-		modules.add(new SpringModule((ConfigurableListableBeanFactory) registry, enableJustInTimeBinding));
+		modules.add(new SpringModule((ConfigurableListableBeanFactory) registry, this.enableJustInTimeBinding));
 		Map<Key<?>, Binding<?>> bindings = new HashMap<Key<?>, Binding<?>>();
 		List<Element> elements = Elements.getElements(Stage.TOOL, modules);
-		if (applicationContext.getEnvironment().getProperty(SPRING_GUICE_DEDUPE_BINDINGS_PROPERTY_NAME, Boolean.class,
-				false)) {
+		if (this.applicationContext.getEnvironment().getProperty(SPRING_GUICE_DEDUPE_BINDINGS_PROPERTY_NAME,
+				Boolean.class, false)) {
 			elements = removeDuplicates(elements);
 			modules = Collections.singletonList(Elements.getModule(elements));
 		}
-		if (applicationContext.getEnvironment().containsProperty("spring.guice.modules.exclude")) {
-			String[] modulesToFilter = applicationContext.getEnvironment()
+		if (this.applicationContext.getEnvironment().containsProperty("spring.guice.modules.exclude")) {
+			String[] modulesToFilter = this.applicationContext.getEnvironment()
 					.getProperty("spring.guice.modules.exclude", "").split(",");
-			elements = elements.stream().filter(e -> elementFilter(modulesToFilter, e)).collect(Collectors.toList());
+			elements = elements.stream().filter((e) -> elementFilter(modulesToFilter, e)).collect(Collectors.toList());
 			modules = Collections.singletonList(Elements.getModule(elements));
 		}
 		for (Element e : elements) {
@@ -124,7 +132,7 @@ class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor
 		RootBeanDefinition beanDefinition = new RootBeanDefinition(GuiceInjectorInitializer.class);
 		ConstructorArgumentValues args = new ConstructorArgumentValues();
 		args.addIndexedArgumentValue(0, modules);
-		args.addIndexedArgumentValue(1, applicationContext);
+		args.addIndexedArgumentValue(1, this.applicationContext);
 		beanDefinition.setConstructorArgumentValues(args);
 		registry.registerBeanDefinition("guiceInjectorInitializer", beanDefinition);
 	}
@@ -135,8 +143,8 @@ class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor
 	}
 
 	private void mapBindings(Map<Key<?>, Binding<?>> bindings, BeanDefinitionRegistry registry) {
-		Stage stage = applicationContext.getEnvironment().getProperty(SPRING_GUICE_STAGE_PROPERTY_NAME, Stage.class,
-				Stage.PRODUCTION);
+		Stage stage = this.applicationContext.getEnvironment().getProperty(SPRING_GUICE_STAGE_PROPERTY_NAME,
+				Stage.class, Stage.PRODUCTION);
 		boolean ifLazyInit = stage.equals(Stage.DEVELOPMENT);
 		for (Entry<Key<?>, Binding<?>> entry : bindings.entrySet()) {
 			if (entry.getKey().getTypeLiteral().getRawType().equals(Injector.class) || SpringModule.SPRING_GUICE_SOURCE
@@ -211,11 +219,11 @@ class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor
 	private boolean elementFilter(String[] modulesToFilter, Element element) {
 		try {
 			return Arrays.stream(modulesToFilter).noneMatch(
-					ex -> Optional.of(element).map(Element::getSource).map(Object::toString).orElse("").contains(ex));
+					(ex) -> Optional.of(element).map(Element::getSource).map(Object::toString).orElse("").contains(ex));
 		}
-		catch (Exception e) {
-			logger.error(String.format("Unable fo filter element[%s] with filter [%s]", element,
-					Arrays.toString(modulesToFilter)), e);
+		catch (Exception ex) {
+			this.logger.error(String.format("Unable fo filter element[%s] with filter [%s]", element,
+					Arrays.toString(modulesToFilter)), ex);
 			return false;
 		}
 	}
@@ -235,22 +243,25 @@ class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor
 
 	/***
 	 * Remove guice-sourced bindings in favor of spring-sourced bindings, when both exist
-	 * for a given binding key
+	 * for a given binding key.
+	 * @param elements list of elements to de-duplicate
+	 * @return de-duplicated list of bindings
 	 */
 	protected List<Element> removeDuplicates(List<Element> elements) {
-		List<Element> duplicateElements = elements.stream().filter(e -> e instanceof Binding).map(e -> (Binding<?>) e)
+		List<Element> duplicateElements = elements.stream().filter((e) -> e instanceof Binding)
+				.map((e) -> (Binding<?>) e)
 				.collect(Collectors.groupingBy(ModuleRegistryConfiguration::getLinkedKeyIfRequired)).entrySet().stream()
-				.filter(e -> e.getValue().size() > 1 && e.getValue().stream()
-						.anyMatch(binding -> binding.getSource() != null
+				.filter((e) -> e.getValue().size() > 1 && e.getValue().stream()
+						.anyMatch((binding) -> binding.getSource() != null
 								&& binding.getSource().toString().contains(SpringModule.SPRING_GUICE_SOURCE))) // find
 																												// duplicates
-				.flatMap(e -> e.getValue().stream())
-				.filter(e -> e.getSource() != null
+				.flatMap((e) -> e.getValue().stream())
+				.filter((e) -> e.getSource() != null
 						&& !e.getSource().toString().contains(SpringModule.SPRING_GUICE_SOURCE))
 				.collect(Collectors.toList());
 
 		@SuppressWarnings("unlikely-arg-type")
-		List<Element> dedupedElements = elements.stream().filter(e -> {
+		List<Element> dedupedElements = elements.stream().filter((e) -> {
 			if (e instanceof Binding) {
 				return !duplicateElements.contains(new SourceComparableBinding((Binding<?>) e));
 			}
@@ -274,11 +285,12 @@ class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor
 		return binding.getKey();
 	}
 
+	@SuppressWarnings("checkstyle:EqualsHashCode")
 	private static class SourceComparableBinding {
 
 		private Binding<?> binding;
 
-		public SourceComparableBinding(Binding<?> binding) {
+		SourceComparableBinding(Binding<?> binding) {
 			this.binding = binding;
 		}
 
@@ -287,10 +299,11 @@ class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor
 			if (obj instanceof Binding) {
 				Binding<?> compareTo = (Binding<?>) obj;
 				if (compareTo.getSource() != null && this.binding != null) {
-					return binding.equals(compareTo) && Objects.equals(binding.getSource(), compareTo.getSource());
+					return this.binding.equals(compareTo)
+							&& Objects.equals(this.binding.getSource(), compareTo.getSource());
 				}
 				else {
-					return Objects.equals(binding, compareTo);
+					return Objects.equals(this.binding, compareTo);
 				}
 			}
 			else {
@@ -300,85 +313,87 @@ class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor
 
 	}
 
-}
+	/**
+	 * Creates the Guice injector and registers it.
+	 *
+	 * The correct time to create the injector is after all Bean Post Processors were
+	 * registered (after the registerBeanPostProcessors() phase), but before other beans
+	 * get resolved. To achieve this, we create the injector when the first bean gets
+	 * resolved - in its post-processing phase. However, this creates a possibility for a
+	 * circular initialization error (i.e. if the first bean is also being dependant on by
+	 * a Guice provided binding). To resolve this we publish an event that will be
+	 * triggered in the registerListeners() phase, and create the injector then. Combining
+	 * both initialization mechanisms (post-processor and the event publishing) ensures
+	 * the injector will be created no later then the registerListeners() phase, but after
+	 * the registerBeanPostProcessors() phase. For application contexts that override
+	 * onRefresh() and create beans then (i.e. WebServer based application contexts) the
+	 * post-processor initialization will kick-in and create the injector before.
+	 */
+	static class GuiceInjectorInitializer
+			implements BeanPostProcessor, ApplicationListener<GuiceInjectorInitializer.CreateInjectorEvent> {
 
-/**
- * Creates the Guice injector and registers it.
- *
- * The correct time to create the injector is after all Bean Post Processors were
- * registered (after the registerBeanPostProcessors() phase), but before other beans get
- * resolved. To achieve this, we create the injector when the first bean gets resolved -
- * in its post-processing phase. However, this creates a possibility for a circular
- * initialization error (i.e. if the first bean is also being dependant on by a Guice
- * provided binding). To resolve this we publish an event that will be triggered in the
- * registerListeners() phase, and create the injector then. Combining both initialization
- * mechanisms (post-processor and the event publishing) ensures the injector will be
- * created no later then the registerListeners() phase, but after the
- * registerBeanPostProcessors() phase. For application contexts that override onRefresh()
- * and create beans then (i.e. WebServer based application contexts) the post-processor
- * initialization will kick-in and create the injector before.
- */
-class GuiceInjectorInitializer
-		implements BeanPostProcessor, ApplicationListener<GuiceInjectorInitializer.CreateInjectorEvent> {
+		private final AtomicBoolean injectorCreated = new AtomicBoolean(false);
 
-	private final AtomicBoolean injectorCreated = new AtomicBoolean(false);
+		private final List<Module> modules;
 
-	private final List<Module> modules;
+		private final ConfigurableApplicationContext applicationContext;
 
-	private final ConfigurableApplicationContext applicationContext;
+		GuiceInjectorInitializer(List<Module> modules, ConfigurableApplicationContext applicationContext) {
+			this.modules = modules;
+			this.applicationContext = applicationContext;
 
-	public GuiceInjectorInitializer(List<Module> modules, ConfigurableApplicationContext applicationContext) {
-		this.modules = modules;
-		this.applicationContext = applicationContext;
-
-		applicationContext.publishEvent(new CreateInjectorEvent());
-	}
-
-	@Override
-	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-		if (injectorCreated.compareAndSet(false, true)) {
-			createInjector();
+			applicationContext.publishEvent(new CreateInjectorEvent());
 		}
-		return bean;
-	}
 
-	@Override
-	public void onApplicationEvent(CreateInjectorEvent event) {
-		if (injectorCreated.compareAndSet(false, true)) {
-			createInjector();
-		}
-	}
-
-	private void createInjector() {
-		Injector injector = null;
-		try {
-			Map<String, InjectorFactory> beansOfType = applicationContext.getBeansOfType(InjectorFactory.class);
-			if (beansOfType.size() > 1) {
-				throw new ApplicationContextException("Found multiple beans of type " + InjectorFactory.class.getName()
-						+ "  Please ensure that only one InjectorFactory bean is defined. InjectorFactory beans found: "
-						+ beansOfType.keySet());
+		@Override
+		public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+			if (this.injectorCreated.compareAndSet(false, true)) {
+				createInjector();
 			}
-			else if (beansOfType.size() == 1) {
-				InjectorFactory injectorFactory = beansOfType.values().iterator().next();
-				injector = injectorFactory.createInjector(modules);
+			return bean;
+		}
+
+		@Override
+		public void onApplicationEvent(CreateInjectorEvent event) {
+			if (this.injectorCreated.compareAndSet(false, true)) {
+				createInjector();
 			}
 		}
-		catch (NoSuchBeanDefinitionException e) {
 
+		private void createInjector() {
+			Injector injector = null;
+			try {
+				Map<String, InjectorFactory> beansOfType = this.applicationContext
+						.getBeansOfType(InjectorFactory.class);
+				if (beansOfType.size() > 1) {
+					throw new ApplicationContextException("Found multiple beans of type "
+							+ InjectorFactory.class.getName()
+							+ "  Please ensure that only one InjectorFactory bean is defined. InjectorFactory beans found: "
+							+ beansOfType.keySet());
+				}
+				else if (beansOfType.size() == 1) {
+					InjectorFactory injectorFactory = beansOfType.values().iterator().next();
+					injector = injectorFactory.createInjector(this.modules);
+				}
+			}
+			catch (NoSuchBeanDefinitionException ex) {
+
+			}
+			if (injector == null) {
+				injector = Guice.createInjector(this.modules);
+			}
+			this.applicationContext.getBeanFactory().registerResolvableDependency(Injector.class, injector);
+			this.applicationContext.getBeanFactory().registerSingleton("injector", injector);
 		}
-		if (injector == null) {
-			injector = Guice.createInjector(modules);
-		}
-		applicationContext.getBeanFactory().registerResolvableDependency(Injector.class, injector);
-		applicationContext.getBeanFactory().registerSingleton("injector", injector);
-	}
 
-	static class CreateInjectorEvent extends ApplicationEvent {
+		static class CreateInjectorEvent extends ApplicationEvent {
 
-		private static final long serialVersionUID = -6546970378679850504L;
+			private static final long serialVersionUID = -6546970378679850504L;
 
-		public CreateInjectorEvent() {
-			super(serialVersionUID);
+			CreateInjectorEvent() {
+				super(serialVersionUID);
+			}
+
 		}
 
 	}

--- a/src/main/java/org/springframework/guice/injector/SpringInjector.java
+++ b/src/main/java/org/springframework/guice/injector/SpringInjector.java
@@ -1,14 +1,17 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.injector;
@@ -17,13 +20,6 @@ import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import com.google.inject.spi.Element;
-import com.google.inject.spi.InjectionPoint;
-import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.beans.factory.support.RootBeanDefinition;
-import org.springframework.context.ApplicationContext;
 
 import com.google.inject.Binding;
 import com.google.inject.Injector;
@@ -34,7 +30,14 @@ import com.google.inject.Provider;
 import com.google.inject.Scope;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.TypeConverterBinding;
+
+import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ApplicationContext;
 
 /**
  * An {@link Injector} that wraps an {@link ApplicationContext}, and can be used to expose

--- a/src/main/java/org/springframework/guice/module/BeanFactoryProvider.java
+++ b/src/main/java/org/springframework/guice/module/BeanFactoryProvider.java
@@ -54,6 +54,7 @@ import org.springframework.core.OrderComparator;
  * @author Dave Syer
  *
  */
+@SuppressWarnings("checkstyle:FinalClass")
 public class BeanFactoryProvider implements Provider<ConfigurableListableBeanFactory>, Closeable {
 
 	private Class<?>[] config;
@@ -112,16 +113,16 @@ public class BeanFactoryProvider implements Provider<ConfigurableListableBeanFac
 			synchronized (this) {
 				if (this.context == null) {
 					PartiallyRefreshableApplicationContext context = new PartiallyRefreshableApplicationContext();
-					if (config != null && config.length > 0) {
-						context.register(config);
+					if (this.config != null && this.config.length > 0) {
+						context.register(this.config);
 					}
-					if (basePackages != null && basePackages.length > 0) {
-						context.scan(basePackages);
+					if (this.basePackages != null && this.basePackages.length > 0) {
+						context.scan(this.basePackages);
 					}
 					context.partialRefresh();
-					if (initializers != null && !initializers.isEmpty()) {
-						OrderComparator.sort(initializers);
-						for (ApplicationContextInitializer<ConfigurableApplicationContext> initializer : initializers) {
+					if (this.initializers != null && !this.initializers.isEmpty()) {
+						OrderComparator.sort(this.initializers);
+						for (ApplicationContextInitializer<ConfigurableApplicationContext> initializer : this.initializers) {
 							initializer.initialize(context);
 						}
 					}
@@ -129,7 +130,7 @@ public class BeanFactoryProvider implements Provider<ConfigurableListableBeanFac
 				}
 			}
 		}
-		return context.getBeanFactory();
+		return this.context.getBeanFactory();
 	}
 
 	private static final class PartiallyRefreshableApplicationContext extends AnnotationConfigApplicationContext {
@@ -157,7 +158,7 @@ public class BeanFactoryProvider implements Provider<ConfigurableListableBeanFac
 
 		@Override
 		protected void invokeBeanFactoryPostProcessors(ConfigurableListableBeanFactory beanFactory) {
-			if (partiallyRefreshed.compareAndSet(false, true)) {
+			if (this.partiallyRefreshed.compareAndSet(false, true)) {
 				super.invokeBeanFactoryPostProcessors(beanFactory);
 			}
 		}
@@ -176,8 +177,8 @@ public class BeanFactoryProvider implements Provider<ConfigurableListableBeanFac
 
 		@Override
 		public <T> void onProvision(ProvisionInvocation<T> provision) {
-			if (!initialized.getAndSet(true) && !context.isActive()) {
-				context.delayedRefresh();
+			if (!this.initialized.getAndSet(true) && !this.context.isActive()) {
+				this.context.delayedRefresh();
 			}
 			provision.provision();
 		}

--- a/src/main/java/org/springframework/guice/module/BindingTypeMatcher.java
+++ b/src/main/java/org/springframework/guice/module/BindingTypeMatcher.java
@@ -19,6 +19,8 @@ package org.springframework.guice.module;
 import java.lang.reflect.Type;
 
 /**
+ * Utility to check whether a binding matches the given name and type.
+ *
  * @author Dave Syer
  *
  */

--- a/src/main/java/org/springframework/guice/module/GuiceModuleMetadata.java
+++ b/src/main/java/org/springframework/guice/module/GuiceModuleMetadata.java
@@ -59,45 +59,45 @@ public class GuiceModuleMetadata implements BindingTypeMatcher {
 	private Set<Class<?>> infrastructureTypes = new HashSet<Class<?>>();
 
 	{
-		infrastructureTypes.add(InitializingBean.class);
-		infrastructureTypes.add(DisposableBean.class);
+		this.infrastructureTypes.add(InitializingBean.class);
+		this.infrastructureTypes.add(DisposableBean.class);
 	}
 
 	private MetadataReaderFactory metadataReaderFactory = new CachingMetadataReaderFactory();
 
 	public GuiceModuleMetadata include(String... filters) {
-		includeNames = filters;
+		this.includeNames = filters;
 		return this;
 	}
 
 	public GuiceModuleMetadata exclude(String... filters) {
-		excludeNames = filters;
+		this.excludeNames = filters;
 		return this;
 	}
 
 	public GuiceModuleMetadata include(Pattern... filters) {
-		includePatterns = filters;
+		this.includePatterns = filters;
 		return this;
 	}
 
 	public GuiceModuleMetadata exclude(Pattern... filters) {
-		excludePatterns = filters;
+		this.excludePatterns = filters;
 		return this;
 	}
 
 	public GuiceModuleMetadata include(TypeFilter... filters) {
-		includeFilters = filters;
+		this.includeFilters = filters;
 		return this;
 	}
 
 	public GuiceModuleMetadata exclude(TypeFilter... filters) {
-		excludeFilters = filters;
+		this.excludeFilters = filters;
 		return this;
 	}
 
 	@Override
 	public boolean matches(String name, Type type) {
-		Type rawType = type instanceof ParameterizedType ? ((ParameterizedType) type).getRawType() : type;
+		Type rawType = (type instanceof ParameterizedType) ? ((ParameterizedType) type).getRawType() : type;
 		if (!matches(name) || !matches(rawType)) {
 			return false;
 		}
@@ -105,27 +105,27 @@ public class GuiceModuleMetadata implements BindingTypeMatcher {
 	}
 
 	private boolean matches(String name) {
-		if (includePatterns != null) {
-			for (Pattern filter : includePatterns) {
+		if (this.includePatterns != null) {
+			for (Pattern filter : this.includePatterns) {
 				if (!filter.matcher(name).matches()) {
 					return false;
 				}
 			}
 		}
-		if (excludePatterns != null) {
-			for (Pattern filter : excludePatterns) {
+		if (this.excludePatterns != null) {
+			for (Pattern filter : this.excludePatterns) {
 				if (filter.matcher(name).matches()) {
 					return false;
 				}
 			}
 		}
-		if (includeNames != null && includeNames.length > 0) {
-			if (!PatternMatchUtils.simpleMatch(includeNames, name)) {
+		if (this.includeNames != null && this.includeNames.length > 0) {
+			if (!PatternMatchUtils.simpleMatch(this.includeNames, name)) {
 				return false;
 			}
 		}
-		if (excludeNames != null && excludeNames.length > 0) {
-			if (PatternMatchUtils.simpleMatch(excludeNames, name)) {
+		if (this.excludeNames != null && this.excludeNames.length > 0) {
+			if (PatternMatchUtils.simpleMatch(this.excludeNames, name)) {
 				return false;
 			}
 		}
@@ -133,7 +133,7 @@ public class GuiceModuleMetadata implements BindingTypeMatcher {
 	}
 
 	private boolean matches(Type type) {
-		if (infrastructureTypes.contains(type)) {
+		if (this.infrastructureTypes.contains(type)) {
 			return false;
 		}
 
@@ -141,30 +141,30 @@ public class GuiceModuleMetadata implements BindingTypeMatcher {
 			return false;
 		}
 
-		if (includeFilters != null) {
+		if (this.includeFilters != null) {
 			try {
-				MetadataReader reader = metadataReaderFactory.getMetadataReader(type.getTypeName());
-				for (TypeFilter filter : includeFilters) {
-					if (!filter.match(reader, metadataReaderFactory)) {
+				MetadataReader reader = this.metadataReaderFactory.getMetadataReader(type.getTypeName());
+				for (TypeFilter filter : this.includeFilters) {
+					if (!filter.match(reader, this.metadataReaderFactory)) {
 						return false;
 					}
 				}
 			}
-			catch (IOException e) {
-				throw new IllegalStateException("Cannot read metadata for class " + type, e);
+			catch (IOException ex) {
+				throw new IllegalStateException("Cannot read metadata for class " + type, ex);
 			}
 		}
-		if (excludeFilters != null) {
+		if (this.excludeFilters != null) {
 			try {
-				MetadataReader reader = metadataReaderFactory.getMetadataReader(type.getTypeName());
-				for (TypeFilter filter : excludeFilters) {
-					if (filter.match(reader, metadataReaderFactory)) {
+				MetadataReader reader = this.metadataReaderFactory.getMetadataReader(type.getTypeName());
+				for (TypeFilter filter : this.excludeFilters) {
+					if (filter.match(reader, this.metadataReaderFactory)) {
 						return false;
 					}
 				}
 			}
-			catch (IOException e) {
-				throw new IllegalStateException("Cannot read metadata for class " + type, e);
+			catch (IOException ex) {
+				throw new IllegalStateException("Cannot read metadata for class " + type, ex);
 			}
 		}
 		return true;

--- a/src/main/java/org/springframework/guice/module/SpringModule.java
+++ b/src/main/java/org/springframework/guice/module/SpringModule.java
@@ -1,14 +1,17 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.module;
@@ -43,8 +46,8 @@ import com.google.inject.matcher.Matchers;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.google.inject.spi.ProvisionListener;
-
 import com.google.inject.util.Types;
+
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
@@ -62,11 +65,16 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
 
 /**
+ * A Guice module that wraps a Spring {@link ApplicationContext}.
+ *
  * @author Dave Syer
  *
  */
 public class SpringModule extends AbstractModule {
 
+	/**
+	 * Identifier for bindings provided by this module.
+	 */
 	public static final String SPRING_GUICE_SOURCE = "spring-guice";
 
 	private BindingTypeMatcher matcher = new GuiceModuleMetadata();
@@ -102,23 +110,24 @@ public class SpringModule extends AbstractModule {
 
 	@Override
 	public void configure() {
-		if (beanFactory == null) {
-			beanFactory = beanFactoryProvider.get();
+		if (this.beanFactory == null) {
+			this.beanFactory = this.beanFactoryProvider.get();
 		}
-		if (beanFactory.getBeanNamesForType(ProvisionListener.class).length > 0) {
-			binder().bindListener(Matchers.any(),
-					beanFactory.getBeansOfType(ProvisionListener.class).values().toArray(new ProvisionListener[0]));
+		if (this.beanFactory.getBeanNamesForType(ProvisionListener.class).length > 0) {
+			binder().bindListener(Matchers.any(), this.beanFactory.getBeansOfType(ProvisionListener.class).values()
+					.toArray(new ProvisionListener[0]));
 		}
-		if (enableJustInTimeBinding) {
-			if (beanFactory instanceof DefaultListableBeanFactory) {
-				((DefaultListableBeanFactory) beanFactory).setAutowireCandidateResolver(
+		if (this.enableJustInTimeBinding) {
+			if (this.beanFactory instanceof DefaultListableBeanFactory) {
+				((DefaultListableBeanFactory) this.beanFactory).setAutowireCandidateResolver(
 						new GuiceAutowireCandidateResolver(binder().getProvider(Injector.class)));
 			}
 		}
-		if (beanFactory.getBeanNamesForType(GuiceModuleMetadata.class).length > 0) {
-			this.matcher = new CompositeTypeMatcher(beanFactory.getBeansOfType(GuiceModuleMetadata.class).values());
+		if (this.beanFactory.getBeanNamesForType(GuiceModuleMetadata.class).length > 0) {
+			this.matcher = new CompositeTypeMatcher(
+					this.beanFactory.getBeansOfType(GuiceModuleMetadata.class).values());
 		}
-		bind(beanFactory);
+		bind(this.beanFactory);
 	}
 
 	private void bind(ConfigurableListableBeanFactory beanFactory) {
@@ -205,9 +214,9 @@ public class SpringModule extends AbstractModule {
 			try {
 				Method factoryMethod = getFactoryMethod(beanFactory, definition);
 				return Arrays.stream(AnnotationUtils.getAnnotations(factoryMethod))
-						.filter(a -> Annotations.isBindingAnnotation(a.annotationType())).findFirst();
+						.filter((a) -> Annotations.isBindingAnnotation(a.annotationType())).findFirst();
 			}
-			catch (Exception e) {
+			catch (Exception ex) {
 				return Optional.empty();
 			}
 		}
@@ -307,7 +316,7 @@ public class SpringModule extends AbstractModule {
 				}
 			}
 		}
-		Key<?> key = bindingAnnotation.map(a -> (Key<Object>) Key.get(type, a)).orElse((Key<Object>) Key.get(type));
+		Key<?> key = bindingAnnotation.map((a) -> (Key<Object>) Key.get(type, a)).orElse((Key<Object>) Key.get(type));
 		StageTypeKey stageTypeKey = new StageTypeKey(binder.currentStage(), key);
 		if (this.bound.get(stageTypeKey) == null) {
 			// Only bind one provider for each type
@@ -328,43 +337,49 @@ public class SpringModule extends AbstractModule {
 
 		private Key<?> key;
 
-		public StageTypeKey(Stage stage, Key<?> key) {
+		StageTypeKey(Stage stage, Key<?> key) {
 			this.stage = stage;
 			this.key = key;
+		}
 
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			StageTypeKey other = (StageTypeKey) obj;
+			if (this.key == null) {
+				if (other.key != null) {
+					return false;
+				}
+			}
+			else if (!this.key.equals(other.key)) {
+				return false;
+			}
+			if (this.stage != other.stage) {
+				return false;
+			}
+			return true;
 		}
 
 		@Override
 		public int hashCode() {
 			final int prime = 31;
 			int result = 1;
-			result = prime * result + ((key == null) ? 0 : key.hashCode());
-			result = prime * result + ((stage == null) ? 0 : stage.hashCode());
+			result = prime * result + ((this.key == null) ? 0 : this.key.hashCode());
+			result = prime * result + ((this.stage == null) ? 0 : this.stage.hashCode());
 			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			StageTypeKey other = (StageTypeKey) obj;
-			if (key == null) {
-				if (other.key != null)
-					return false;
-			}
-			else if (!key.equals(other.key))
-				return false;
-			if (stage != other.stage)
-				return false;
-			return true;
 		}
 
 	}
 
+	@SuppressWarnings("checkstyle:FinalClass")
 	private static class BeanFactoryProvider implements Provider<Object> {
 
 		private ConfigurableListableBeanFactory beanFactory;
@@ -385,42 +400,46 @@ public class SpringModule extends AbstractModule {
 			this.type = type;
 		}
 
+		@SuppressWarnings("checkstyle:SpringMethodVisibility")
 		public static Provider<?> named(ConfigurableListableBeanFactory beanFactory, String name, Type type,
 				Optional<Annotation> bindingAnnotation) {
 			return new BeanFactoryProvider(beanFactory, name, type, bindingAnnotation);
 		}
 
+		@SuppressWarnings("checkstyle:SpringMethodVisibility")
 		public static Provider<?> typed(ConfigurableListableBeanFactory beanFactory, Type type,
 				Optional<Annotation> bindingAnnotation) {
 			return new BeanFactoryProvider(beanFactory, null, type, bindingAnnotation);
 		}
 
 		@Override
+		@SuppressWarnings("checkstyle:NestedIfDepth")
 		public Object get() {
 			if (this.resultProvider == null) {
 
 				String[] named = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(this.beanFactory,
-						ResolvableType.forType(type));
+						ResolvableType.forType(this.type));
 				List<String> names = new ArrayList<String>(named.length);
 				if (named.length == 1) {
 					names.add(named[0]);
 				}
 				else {
 					for (String name : named) {
-						if (bindingAnnotation.isPresent()) {
-							if (bindingAnnotation.get() instanceof Named
-									|| bindingAnnotation.get() instanceof javax.inject.Named) {
+						if (this.bindingAnnotation.isPresent()) {
+							if (this.bindingAnnotation.get() instanceof Named
+									|| this.bindingAnnotation.get() instanceof javax.inject.Named) {
 								Optional<Annotation> annotation = SpringModule.getAnnotationForBeanDefinition(
-										beanFactory.getMergedBeanDefinition(name), beanFactory);
-								String boundName = getNameFromBindingAnnotation(bindingAnnotation);
-								if (annotation.isPresent() && bindingAnnotation.get().equals(annotation.get())
+										this.beanFactory.getMergedBeanDefinition(name), this.beanFactory);
+								String boundName = getNameFromBindingAnnotation(this.bindingAnnotation);
+								if (annotation.isPresent() && this.bindingAnnotation.get().equals(annotation.get())
 										|| name.equals(boundName)) {
 									names.add(name);
 								}
 							}
 						}
-						if (name.equals(this.name))
+						if (name.equals(this.name)) {
 							names.add(name);
+						}
 					}
 				}
 				if (names.size() == 1) {
@@ -447,7 +466,7 @@ public class SpringModule extends AbstractModule {
 
 		private Collection<? extends BindingTypeMatcher> matchers;
 
-		public CompositeTypeMatcher(Collection<? extends BindingTypeMatcher> matchers) {
+		CompositeTypeMatcher(Collection<? extends BindingTypeMatcher> matchers) {
 			this.matchers = matchers;
 		}
 

--- a/src/test/java/org/springframework/guice/AbstractCompleteWiringTests.java
+++ b/src/test/java/org/springframework/guice/AbstractCompleteWiringTests.java
@@ -23,17 +23,17 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public abstract class AbstractCompleteWiringTests {
 
 	private Injector injector;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		this.injector = createInjector();
 	}

--- a/src/test/java/org/springframework/guice/AbstractCompleteWiringTests.java
+++ b/src/test/java/org/springframework/guice/AbstractCompleteWiringTests.java
@@ -26,8 +26,7 @@ import com.google.inject.name.Names;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractCompleteWiringTests {
 
@@ -44,58 +43,58 @@ public abstract class AbstractCompleteWiringTests {
 	public void injectInstance() {
 		Bar bar = new Bar();
 		this.injector.injectMembers(bar);
-		assertNotNull(bar.service);
+		assertThat(bar.service).isNotNull();
 	}
 
 	@Test
 	public void memberInjector() {
 		Bar bar = new Bar();
 		this.injector.getMembersInjector(Bar.class).injectMembers(bar);
-		assertNotNull(bar.service);
+		assertThat(bar.service).isNotNull();
 	}
 
 	@Test
 	public void getInstanceUnbound() {
-		assertNotNull(this.injector.getInstance(Foo.class));
+		assertThat(this.injector.getInstance(Foo.class)).isNotNull();
 	}
 
 	@Test
 	public void getInstanceBound() {
-		assertNotNull(this.injector.getInstance(Service.class));
+		assertThat(this.injector.getInstance(Service.class)).isNotNull();
 	}
 
 	@Test
 	public void getInstanceBoundWithNoInterface() {
 		Baz instance = this.injector.getInstance(Baz.class);
-		assertNotNull(instance);
-		assertEquals(instance, this.injector.getInstance(Baz.class));
+		assertThat(instance).isNotNull();
+		assertThat(this.injector.getInstance(Baz.class)).isEqualTo(instance);
 	}
 
 	@Test
 	public void getProviderUnbound() {
-		assertNotNull(this.injector.getProvider(Foo.class).get());
+		assertThat(this.injector.getProvider(Foo.class).get()).isNotNull();
 	}
 
 	@Test
 	public void getProviderBound() {
-		assertNotNull(this.injector.getProvider(Service.class).get());
+		assertThat(this.injector.getProvider(Service.class).get()).isNotNull();
 	}
 
 	@Test
 	public void getNamedInstance() {
-		assertNotNull(this.injector.getInstance(Key.get(Thang.class, Names.named("thing"))));
+		assertThat(this.injector.getInstance(Key.get(Thang.class, Names.named("thing")))).isNotNull();
 	}
 
 	@Test
 	public void getNamedInjectedInstance() {
-		assertNotNull(this.injector.getInstance(Thing.class).thang);
+		assertThat(this.injector.getInstance(Thing.class).thang).isNotNull();
 	}
 
 	@Test
 	public void getParameterizedType() {
 		Parameterized<String> instance = this.injector.getInstance(Key.get(new TypeLiteral<Parameterized<String>>() {
 		}));
-		assertNotNull(instance);
+		assertThat(instance).isNotNull();
 	}
 
 	public interface Service {

--- a/src/test/java/org/springframework/guice/AbstractCompleteWiringTests.java
+++ b/src/test/java/org/springframework/guice/AbstractCompleteWiringTests.java
@@ -1,18 +1,33 @@
-package org.springframework.guice;
+/*
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+package org.springframework.guice;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-
-import org.junit.Before;
-import org.junit.Test;
 
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public abstract class AbstractCompleteWiringTests {
 
@@ -133,7 +148,7 @@ public abstract class AbstractCompleteWiringTests {
 
 	}
 
-	public static interface Parameterized<T> {
+	public interface Parameterized<T> {
 
 	}
 

--- a/src/test/java/org/springframework/guice/AdhocTestSuite.java
+++ b/src/test/java/org/springframework/guice/AdhocTestSuite.java
@@ -16,10 +16,9 @@
 
 package org.springframework.guice;
 
-import org.junit.Ignore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.jupiter.api.Disabled;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 import org.springframework.guice.annotation.EnableGuiceModulesTests;
 
@@ -28,9 +27,9 @@ import org.springframework.guice.annotation.EnableGuiceModulesTests;
  *
  * @author Dave Syer
  */
-@RunWith(Suite.class)
-@SuiteClasses({ BindingDeduplicationTests.class, EnableGuiceModulesTests.class })
-@Ignore
+@Suite
+@SelectClasses({ BindingDeduplicationTests.class, EnableGuiceModulesTests.class })
+@Disabled
 public class AdhocTestSuite {
 
 }

--- a/src/test/java/org/springframework/guice/BeanPostProcessorTests.java
+++ b/src/test/java/org/springframework/guice/BeanPostProcessorTests.java
@@ -20,7 +20,7 @@ import javax.inject.Inject;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BeanPostProcessorTests {
 

--- a/src/test/java/org/springframework/guice/BeanPostProcessorTests.java
+++ b/src/test/java/org/springframework/guice/BeanPostProcessorTests.java
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BeanPostProcessorTests {
 
@@ -46,11 +46,11 @@ public class BeanPostProcessorTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 				BeanPostProcessorTestConfig.class);
 		PostProcessedBean postProcessedBean = context.getBean(PostProcessedBean.class);
-		assertTrue(postProcessedBean.postProcessed);
+		assertThat(postProcessedBean.postProcessed).isTrue();
 		GuiceBeanThatWantsPostProcessedBean guiceBean1 = context.getBean(GuiceBeanThatWantsPostProcessedBean.class);
-		assertTrue(guiceBean1.ppb.postProcessed);
+		assertThat(guiceBean1.ppb.postProcessed).isTrue();
 		GuiceBeanThatWantsSpringBean guiceBean2 = context.getBean(GuiceBeanThatWantsSpringBean.class);
-		assertTrue(guiceBean2.springBean.ppb.postProcessed);
+		assertThat(guiceBean2.springBean.ppb.postProcessed).isTrue();
 		context.close();
 	}
 

--- a/src/test/java/org/springframework/guice/BindingAnnotationTests.java
+++ b/src/test/java/org/springframework/guice/BindingAnnotationTests.java
@@ -29,7 +29,7 @@ import com.google.inject.BindingAnnotation;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.name.Names;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -37,8 +37,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class BindingAnnotationTests {
 
@@ -87,8 +87,10 @@ public class BindingAnnotationTests {
 		assertNotNull(injector.getInstance(SomeNamedDepWithType1.class));
 		assertNotNull(injector.getInstance(SomeNamedDepWithType2.class));
 
-		assertNotNull(injector.getInstance(Key.get(SomeNamedDepWithType1.class, Names.named("sameNameDifferentType"))));
-		assertNotNull(injector.getInstance(Key.get(SomeNamedDepWithType2.class, Names.named("sameNameDifferentType"))));
+		assertNotNull(
+				injector.getInstance(Key.get(SomeNamedDepWithType1.class, Names.named("sameNameDifferentType"))));
+		assertNotNull(
+				injector.getInstance(Key.get(SomeNamedDepWithType2.class, Names.named("sameNameDifferentType"))));
 		context.close();
 	}
 

--- a/src/test/java/org/springframework/guice/BindingAnnotationTests.java
+++ b/src/test/java/org/springframework/guice/BindingAnnotationTests.java
@@ -1,7 +1,20 @@
-package org.springframework.guice;
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+package org.springframework.guice;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -12,25 +25,20 @@ import javax.inject.Named;
 import javax.inject.Qualifier;
 
 import com.google.inject.AbstractModule;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.guice.BindingAnnotationTests.SomeDependencyWithBindingAnnotationOnProvider;
-import org.springframework.guice.BindingAnnotationTests.SomeDependencyWithGuiceNamedAnnotationOnProvider;
-import org.springframework.guice.BindingAnnotationTests.SomeDependencyWithNamedAnnotationOnProvider;
-import org.springframework.guice.BindingAnnotationTests.SomeDependencyWithQualifierOnProvider;
-import org.springframework.guice.BindingAnnotationTests.SomeDependencyWithQualifierOnProviderWhichImplementsSomeInterface;
-import org.springframework.guice.BindingAnnotationTests.SomeInterface;
-import org.springframework.guice.BindingAnnotationTests.SomeNamedDepWithType1;
-import org.springframework.guice.BindingAnnotationTests.SomeNamedDepWithType2;
-import org.springframework.guice.annotation.EnableGuiceModules;
-
 import com.google.inject.BindingAnnotation;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.name.Names;
+import org.junit.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.guice.annotation.EnableGuiceModules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class BindingAnnotationTests {
 
@@ -116,113 +124,113 @@ public class BindingAnnotationTests {
 
 	}
 
-}
+	@Qualifier
+	@Target({ ElementType.TYPE, ElementType.METHOD })
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface SomeQualifierAnnotation {
 
-@Qualifier
-@Target({ ElementType.TYPE, ElementType.METHOD })
-@Retention(RetentionPolicy.RUNTIME)
-@interface SomeQualifierAnnotation {
-
-}
-
-@BindingAnnotation
-@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD })
-@Retention(RetentionPolicy.RUNTIME)
-@interface SomeBindingAnnotation {
-
-}
-
-@BindingAnnotation
-@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD })
-@Retention(RetentionPolicy.RUNTIME)
-@interface SomeOtherBindingAnnotation {
-
-}
-
-class SomeStringHolder {
-
-	@Autowired
-	@SomeBindingAnnotation
-	public String annotatedString;
-
-	@Autowired
-	@SomeOtherBindingAnnotation
-	String otherAnnotatedString;
-
-}
-
-@EnableGuiceModules
-@Configuration
-class BindingAnnotationTestsConfig {
-
-	@Bean
-	@SomeQualifierAnnotation
-	public SomeDependencyWithQualifierOnProvider someDependencyWithQualifierOnProvider() {
-		return new SomeDependencyWithQualifierOnProvider();
 	}
 
-	@Bean
-	@SomeBindingAnnotation
-	public SomeDependencyWithBindingAnnotationOnProvider someDependencyWithBindingAnnotationOnProvider() {
-		return new SomeDependencyWithBindingAnnotationOnProvider();
+	@BindingAnnotation
+	@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD })
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface SomeBindingAnnotation {
+
 	}
 
-	@Bean
-	@Named("javaxNamed")
-	public SomeDependencyWithNamedAnnotationOnProvider someDependencyWithNamedAnnotationOnProvider() {
-		return new SomeDependencyWithNamedAnnotationOnProvider();
+	@BindingAnnotation
+	@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD })
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface SomeOtherBindingAnnotation {
+
 	}
 
-	@Bean(name = "javaxNamed2")
-	@Named("javaxNamed2")
-	public SomeDependencyWithNamedAnnotationOnProvider someSecondDependencyWithNamedAnnotationOnProvider() {
-		return new SomeDependencyWithNamedAnnotationOnProvider();
+	static class SomeStringHolder {
+
+		@Autowired
+		@SomeBindingAnnotation
+		public String annotatedString;
+
+		@Autowired
+		@SomeOtherBindingAnnotation
+		String otherAnnotatedString;
+
 	}
 
-	@Bean
-	@com.google.inject.name.Named("guiceNamed")
-	public SomeDependencyWithGuiceNamedAnnotationOnProvider someDependencyWithGuiceNamedAnnotationOnProvider() {
-		return new SomeDependencyWithGuiceNamedAnnotationOnProvider();
-	}
+	@EnableGuiceModules
+	@Configuration
+	static class BindingAnnotationTestsConfig {
 
-	@Bean
-	@com.google.inject.name.Named("guiceNamed2")
-	public SomeDependencyWithGuiceNamedAnnotationOnProvider someSecondDependencyWithGuiceNamedAnnotationOnProvider() {
-		return new SomeDependencyWithGuiceNamedAnnotationOnProvider();
-	}
+		@Bean
+		@SomeQualifierAnnotation
+		SomeDependencyWithQualifierOnProvider someDependencyWithQualifierOnProvider() {
+			return new SomeDependencyWithQualifierOnProvider();
+		}
 
-	@Bean
-	@SomeQualifierAnnotation
-	public SomeInterface someInterface() {
-		return new SomeDependencyWithQualifierOnProviderWhichImplementsSomeInterface();
-	}
+		@Bean
+		@SomeBindingAnnotation
+		SomeDependencyWithBindingAnnotationOnProvider someDependencyWithBindingAnnotationOnProvider() {
+			return new SomeDependencyWithBindingAnnotationOnProvider();
+		}
 
-	@Bean
-	@Named("sameNameDifferentType")
-	public SomeNamedDepWithType1 someNamedDepWithType1() {
-		return new SomeNamedDepWithType1();
-	}
+		@Bean
+		@Named("javaxNamed")
+		SomeDependencyWithNamedAnnotationOnProvider someDependencyWithNamedAnnotationOnProvider() {
+			return new SomeDependencyWithNamedAnnotationOnProvider();
+		}
 
-	@Bean
-	@Named("sameNameDifferentType")
-	public SomeNamedDepWithType2 someNamedDepWithType2() {
-		return new SomeNamedDepWithType2();
-	}
+		@Bean(name = "javaxNamed2")
+		@Named("javaxNamed2")
+		SomeDependencyWithNamedAnnotationOnProvider someSecondDependencyWithNamedAnnotationOnProvider() {
+			return new SomeDependencyWithNamedAnnotationOnProvider();
+		}
 
-	@Bean
-	public SomeStringHolder stringHolder() {
-		return new SomeStringHolder();
-	}
+		@Bean
+		@com.google.inject.name.Named("guiceNamed")
+		SomeDependencyWithGuiceNamedAnnotationOnProvider someDependencyWithGuiceNamedAnnotationOnProvider() {
+			return new SomeDependencyWithGuiceNamedAnnotationOnProvider();
+		}
 
-	@Bean
-	public AbstractModule module() {
-		return new AbstractModule() {
-			@Override
-			protected void configure() {
-				bind(String.class).annotatedWith(SomeBindingAnnotation.class).toInstance("annotated");
-				bind(String.class).annotatedWith(SomeOtherBindingAnnotation.class).toInstance("other");
-			}
-		};
+		@Bean
+		@com.google.inject.name.Named("guiceNamed2")
+		SomeDependencyWithGuiceNamedAnnotationOnProvider someSecondDependencyWithGuiceNamedAnnotationOnProvider() {
+			return new SomeDependencyWithGuiceNamedAnnotationOnProvider();
+		}
+
+		@Bean
+		@SomeQualifierAnnotation
+		SomeInterface someInterface() {
+			return new SomeDependencyWithQualifierOnProviderWhichImplementsSomeInterface();
+		}
+
+		@Bean
+		@Named("sameNameDifferentType")
+		SomeNamedDepWithType1 someNamedDepWithType1() {
+			return new SomeNamedDepWithType1();
+		}
+
+		@Bean
+		@Named("sameNameDifferentType")
+		SomeNamedDepWithType2 someNamedDepWithType2() {
+			return new SomeNamedDepWithType2();
+		}
+
+		@Bean
+		SomeStringHolder stringHolder() {
+			return new SomeStringHolder();
+		}
+
+		@Bean
+		AbstractModule module() {
+			return new AbstractModule() {
+				@Override
+				protected void configure() {
+					bind(String.class).annotatedWith(SomeBindingAnnotation.class).toInstance("annotated");
+					bind(String.class).annotatedWith(SomeOtherBindingAnnotation.class).toInstance("other");
+				}
+			};
+		}
+
 	}
 
 }

--- a/src/test/java/org/springframework/guice/BindingAnnotationTests.java
+++ b/src/test/java/org/springframework/guice/BindingAnnotationTests.java
@@ -37,8 +37,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BindingAnnotationTests {
 
@@ -51,46 +50,46 @@ public class BindingAnnotationTests {
 		// Check @Qualifier
 		SomeDependencyWithQualifierOnProvider someDependencyWithQualifierOnClass = injector
 				.getInstance(Key.get(SomeDependencyWithQualifierOnProvider.class, SomeQualifierAnnotation.class));
-		assertNotNull(someDependencyWithQualifierOnClass);
+		assertThat(someDependencyWithQualifierOnClass).isNotNull();
 
 		// Check @BindingAnnotation on Spring @Bean available in Guice
 		SomeDependencyWithQualifierOnProvider someDependencyWithBindingAnnotationOnProvider = injector
 				.getInstance(Key.get(SomeDependencyWithQualifierOnProvider.class, SomeQualifierAnnotation.class));
-		assertNotNull(someDependencyWithBindingAnnotationOnProvider);
+		assertThat(someDependencyWithBindingAnnotationOnProvider).isNotNull();
 
 		// Check @BindingAnnotation on Guice Binding available in Spring
 		SomeStringHolder stringHolder = context.getBean(SomeStringHolder.class);
-		assertEquals("annotated", stringHolder.annotatedString);
-		assertEquals("other", stringHolder.otherAnnotatedString);
+		assertThat(stringHolder.annotatedString).isEqualTo("annotated");
+		assertThat(stringHolder.otherAnnotatedString).isEqualTo("other");
 
 		// Check javax @Named
 		SomeDependencyWithNamedAnnotationOnProvider someDependencyWithNamedAnnotationOnProvider = injector
 				.getInstance(Key.get(SomeDependencyWithNamedAnnotationOnProvider.class, Names.named("javaxNamed")));
-		assertNotNull(someDependencyWithNamedAnnotationOnProvider);
+		assertThat(someDependencyWithNamedAnnotationOnProvider).isNotNull();
 
 		// Check Guice @Named
 		SomeDependencyWithGuiceNamedAnnotationOnProvider someDependencyWithGuiceNamedAnnotationOnProvider = injector
 				.getInstance(
 						Key.get(SomeDependencyWithGuiceNamedAnnotationOnProvider.class, Names.named("guiceNamed")));
-		assertNotNull(someDependencyWithGuiceNamedAnnotationOnProvider);
+		assertThat(someDependencyWithGuiceNamedAnnotationOnProvider).isNotNull();
 
 		SomeDependencyWithGuiceNamedAnnotationOnProvider someSecondDependencyWithGuiceNamedAnnotationOnProvider = injector
 				.getInstance(
 						Key.get(SomeDependencyWithGuiceNamedAnnotationOnProvider.class, Names.named("guiceNamed2")));
-		assertNotNull(someSecondDependencyWithGuiceNamedAnnotationOnProvider);
+		assertThat(someSecondDependencyWithGuiceNamedAnnotationOnProvider).isNotNull();
 
 		// Check @Qualifier with Interface
 		SomeInterface someInterface = injector.getInstance(Key.get(SomeInterface.class, SomeQualifierAnnotation.class));
-		assertNotNull(someInterface);
+		assertThat(someInterface).isNotNull();
 
 		// Check different types with same @Named
-		assertNotNull(injector.getInstance(SomeNamedDepWithType1.class));
-		assertNotNull(injector.getInstance(SomeNamedDepWithType2.class));
+		assertThat(injector.getInstance(SomeNamedDepWithType1.class)).isNotNull();
+		assertThat(injector.getInstance(SomeNamedDepWithType2.class)).isNotNull();
 
-		assertNotNull(
-				injector.getInstance(Key.get(SomeNamedDepWithType1.class, Names.named("sameNameDifferentType"))));
-		assertNotNull(
-				injector.getInstance(Key.get(SomeNamedDepWithType2.class, Names.named("sameNameDifferentType"))));
+		assertThat(injector.getInstance(Key.get(SomeNamedDepWithType1.class, Names.named("sameNameDifferentType"))))
+				.isNotNull();
+		assertThat(injector.getInstance(Key.get(SomeNamedDepWithType2.class, Names.named("sameNameDifferentType"))))
+				.isNotNull();
 		context.close();
 	}
 

--- a/src/test/java/org/springframework/guice/BindingDeduplicationTests.java
+++ b/src/test/java/org/springframework/guice/BindingDeduplicationTests.java
@@ -1,17 +1,31 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.CreationException;
 import com.google.inject.Module;
-
 import com.google.inject.multibindings.OptionalBinder;
 import org.junit.AfterClass;
 import org.junit.Test;
+
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.guice.BindingDeduplicationTests.SomeDependency;
-import org.springframework.guice.BindingDeduplicationTests.SomeOptionalDependency;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
 import static org.junit.Assert.assertNotNull;
@@ -51,32 +65,32 @@ public class BindingDeduplicationTests {
 
 	}
 
-}
+	@EnableGuiceModules
+	@Configuration
+	static class BindingDeduplicationTestsConfig {
 
-@EnableGuiceModules
-@Configuration
-class BindingDeduplicationTestsConfig {
+		@Bean
+		SomeDependency someBean() {
+			return new SomeDependency();
+		}
 
-	@Bean
-	public SomeDependency someBean() {
-		return new SomeDependency();
-	}
+		@Bean
+		SomeOptionalDependency someOptionalBean() {
+			return new SomeOptionalDependency();
+		}
 
-	@Bean
-	public SomeOptionalDependency someOptionalBean() {
-		return new SomeOptionalDependency();
-	}
+		@Bean
+		Module module() {
+			return new AbstractModule() {
+				@Override
+				protected void configure() {
+					bind(SomeDependency.class).asEagerSingleton();
+					OptionalBinder.newOptionalBinder(binder(), SomeOptionalDependency.class).setDefault()
+							.to(SomeOptionalDependency.class);
+				}
+			};
+		}
 
-	@Bean
-	public Module module() {
-		return new AbstractModule() {
-			@Override
-			protected void configure() {
-				bind(SomeDependency.class).asEagerSingleton();
-				OptionalBinder.newOptionalBinder(binder(), SomeOptionalDependency.class).setDefault()
-						.to(SomeOptionalDependency.class);
-			}
-		};
 	}
 
 }

--- a/src/test/java/org/springframework/guice/BindingDeduplicationTests.java
+++ b/src/test/java/org/springframework/guice/BindingDeduplicationTests.java
@@ -28,8 +28,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class BindingDeduplicationTests {
 
@@ -44,16 +44,16 @@ public class BindingDeduplicationTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 				BindingDeduplicationTestsConfig.class);
 		SomeDependency someDependency = context.getBean(SomeDependency.class);
-		assertNotNull(someDependency);
+		assertThat(someDependency).isNotNull();
 		SomeOptionalDependency someOptionalDependency = context.getBean(SomeOptionalDependency.class);
-		assertNotNull(someOptionalDependency);
+		assertThat(someOptionalDependency).isNotNull();
 		context.close();
 	}
 
 	@Test
 	public void verifyDuplicateBindingErrorWhenDedupeNotEnabled() {
 		System.setProperty("spring.guice.dedup", "false");
-		assertThrows(CreationException.class, () -> {
+		assertThatExceptionOfType(CreationException.class).isThrownBy(() -> {
 			AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 					BindingDeduplicationTestsConfig.class);
 			context.close();

--- a/src/test/java/org/springframework/guice/BindingDeduplicationTests.java
+++ b/src/test/java/org/springframework/guice/BindingDeduplicationTests.java
@@ -20,19 +20,20 @@ import com.google.inject.AbstractModule;
 import com.google.inject.CreationException;
 import com.google.inject.Module;
 import com.google.inject.multibindings.OptionalBinder;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BindingDeduplicationTests {
 
-	@AfterClass
+	@AfterAll
 	public static void cleanUp() {
 		System.clearProperty("spring.guice.dedup");
 	}
@@ -49,12 +50,14 @@ public class BindingDeduplicationTests {
 		context.close();
 	}
 
-	@Test(expected = CreationException.class)
+	@Test
 	public void verifyDuplicateBindingErrorWhenDedupeNotEnabled() {
 		System.setProperty("spring.guice.dedup", "false");
-		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
-				BindingDeduplicationTestsConfig.class);
-		context.close();
+		assertThrows(CreationException.class, () -> {
+			AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+					BindingDeduplicationTestsConfig.class);
+			context.close();
+		});
 	}
 
 	public static class SomeDependency {

--- a/src/test/java/org/springframework/guice/DuplicateNamesDifferentTypesTests.java
+++ b/src/test/java/org/springframework/guice/DuplicateNamesDifferentTypesTests.java
@@ -21,7 +21,7 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class DuplicateNamesDifferentTypesTests {
 

--- a/src/test/java/org/springframework/guice/DuplicateNamesDifferentTypesTests.java
+++ b/src/test/java/org/springframework/guice/DuplicateNamesDifferentTypesTests.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DuplicateNamesDifferentTypesTests {
 
@@ -41,16 +41,16 @@ public class DuplicateNamesDifferentTypesTests {
 				DuplicateNamesDifferentTypesTestsConfig.class);
 
 		// Check Guice @Named
-		assertNotNull(context.getBean(SomeNamedDepWithType1.class));
-		assertNotNull(context.getBean(SomeNamedDepWithType2.class));
-		assertNotNull(BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(),
-				SomeNamedDepWithType1.class, "sameNameDifferentType"));
+		assertThat(context.getBean(SomeNamedDepWithType1.class)).isNotNull();
+		assertThat(context.getBean(SomeNamedDepWithType2.class)).isNotNull();
+		assertThat(BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(), SomeNamedDepWithType1.class,
+				"sameNameDifferentType")).isNotNull();
 
 		// Check javax @Named
-		assertNotNull(context.getBean(SomeJavaxNamedDepWithType1.class));
-		assertNotNull(context.getBean(SomeJavaxNamedDepWithType2.class));
-		assertNotNull(BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(),
-				SomeJavaxNamedDepWithType1.class, "sameJavaxName"));
+		assertThat(context.getBean(SomeJavaxNamedDepWithType1.class)).isNotNull();
+		assertThat(context.getBean(SomeJavaxNamedDepWithType2.class)).isNotNull();
+		assertThat(BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(),
+				SomeJavaxNamedDepWithType1.class, "sameJavaxName")).isNotNull();
 		context.getBeansOfType(SomeJavaxNamedDepWithType1.class);
 
 		context.close();

--- a/src/test/java/org/springframework/guice/DuplicateNamesDifferentTypesTests.java
+++ b/src/test/java/org/springframework/guice/DuplicateNamesDifferentTypesTests.java
@@ -1,25 +1,37 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
-
-import static org.junit.Assert.assertNotNull;
-
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.guice.DuplicateNamesDifferentTypesTests.SomeJavaxNamedDepWithType1;
-import org.springframework.guice.DuplicateNamesDifferentTypesTests.SomeJavaxNamedDepWithType2;
-import org.springframework.guice.DuplicateNamesDifferentTypesTests.SomeNamedDepWithType1;
-import org.springframework.guice.DuplicateNamesDifferentTypesTests.SomeNamedDepWithType2;
-import org.springframework.guice.annotation.EnableGuiceModules;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
+import org.junit.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.guice.annotation.EnableGuiceModules;
+
+import static org.junit.Assert.assertNotNull;
 
 public class DuplicateNamesDifferentTypesTests {
 
@@ -76,35 +88,35 @@ public class DuplicateNamesDifferentTypesTests {
 
 	}
 
-}
+	@EnableGuiceModules
+	@Configuration
+	static class DuplicateNamesDifferentTypesTestsConfig {
 
-@EnableGuiceModules
-@Configuration
-class DuplicateNamesDifferentTypesTestsConfig {
+		@Bean
+		Module module() {
+			return new AbstractModule() {
+				@Override
+				protected void configure() {
+					bind(SomeNamedDepWithType1.class).annotatedWith(Names.named("sameNameDifferentType"))
+							.to(SomeNamedDepWithType1.class);
+					bind(SomeNamedDepWithType2.class).annotatedWith(Names.named("sameNameDifferentType"))
+							.to(SomeNamedDepWithType2.class);
+				}
 
-	@Bean
-	public Module module() {
-		return new AbstractModule() {
-			@Override
-			protected void configure() {
-				bind(SomeNamedDepWithType1.class).annotatedWith(Names.named("sameNameDifferentType"))
-						.to(SomeNamedDepWithType1.class);
-				bind(SomeNamedDepWithType2.class).annotatedWith(Names.named("sameNameDifferentType"))
-						.to(SomeNamedDepWithType2.class);
-			}
+				@Provides
+				@Named("sameJavaxName")
+				SomeJavaxNamedDepWithType1 someJavaxNamedDepWithType1() {
+					return new SomeJavaxNamedDepWithType1();
+				}
 
-			@Provides
-			@Named("sameJavaxName")
-			public SomeJavaxNamedDepWithType1 someJavaxNamedDepWithType1() {
-				return new SomeJavaxNamedDepWithType1();
-			}
+				@Provides
+				@Named("sameJavaxName")
+				SomeJavaxNamedDepWithType2 someJavaxNamedDepWithType2() {
+					return new SomeJavaxNamedDepWithType2();
+				}
+			};
+		}
 
-			@Provides
-			@Named("sameJavaxName")
-			public SomeJavaxNamedDepWithType2 someJavaxNamedDepWithType2() {
-				return new SomeJavaxNamedDepWithType2();
-			}
-		};
 	}
 
 }

--- a/src/test/java/org/springframework/guice/ElementVisitorTests.java
+++ b/src/test/java/org/springframework/guice/ElementVisitorTests.java
@@ -27,9 +27,9 @@ import com.google.inject.Module;
 import com.google.inject.Stage;
 import com.google.inject.spi.Element;
 import com.google.inject.spi.Elements;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -37,19 +37,19 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ElementVisitorTests {
 
 	private static AnnotationConfigApplicationContext context;
 
-	@BeforeClass
+	@BeforeAll
 	public static void init() {
 		System.setProperty("spring.guice.dedup", "true");
 		context = new AnnotationConfigApplicationContext(ElementVisitorTestConfig.class);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void cleanup() {
 		System.clearProperty("spring.guice.dedup");
 		if (context != null) {

--- a/src/test/java/org/springframework/guice/ElementVisitorTests.java
+++ b/src/test/java/org/springframework/guice/ElementVisitorTests.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ElementVisitorTests {
 
@@ -60,9 +60,9 @@ public class ElementVisitorTests {
 	@Test
 	public void verifySpringModuleDoesNotBreakWhenUsingElementVisitors() {
 		ElementVisitorTestSpringBean testSpringBean = context.getBean(ElementVisitorTestSpringBean.class);
-		assertEquals("spring created", testSpringBean.toString());
+		assertThat(testSpringBean.toString()).isEqualTo("spring created");
 		ElementVisitorTestGuiceBean testGuiceBean = context.getBean(ElementVisitorTestGuiceBean.class);
-		assertEquals("spring created", testGuiceBean.toString());
+		assertThat(testGuiceBean.toString()).isEqualTo("spring created");
 	}
 
 	public static class ElementVisitorTestSpringBean {

--- a/src/test/java/org/springframework/guice/GuiceWiringTests.java
+++ b/src/test/java/org/springframework/guice/GuiceWiringTests.java
@@ -1,14 +1,17 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice;

--- a/src/test/java/org/springframework/guice/InjectorFactoryTests.java
+++ b/src/test/java/org/springframework/guice/InjectorFactoryTests.java
@@ -1,9 +1,26 @@
+/*
+ * Copyright 2016-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
 
+import com.google.inject.Guice;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.BeanCreationException;
+
 import org.springframework.context.ApplicationContextException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -11,12 +28,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
 
-import com.google.inject.Guice;
-import com.google.inject.Module;
-
 public class InjectorFactoryTests {
 
-	static final private InjectorFactory injectorFactory = Mockito.mock(InjectorFactory.class);
+	private static final InjectorFactory injectorFactory = Mockito.mock(InjectorFactory.class);
 
 	@Before
 	public void init() {
@@ -48,7 +62,7 @@ public class InjectorFactoryTests {
 	static class InjectorFactoryConfig {
 
 		@Bean
-		public InjectorFactory injectorFactory() {
+		InjectorFactory injectorFactory() {
 			return injectorFactory;
 		}
 
@@ -58,7 +72,7 @@ public class InjectorFactoryTests {
 	static class SecondInjectorFactoryConfig {
 
 		@Bean
-		public InjectorFactory injectorFactory2() {
+		InjectorFactory injectorFactory2() {
 			return injectorFactory;
 		}
 

--- a/src/test/java/org/springframework/guice/InjectorFactoryTests.java
+++ b/src/test/java/org/springframework/guice/InjectorFactoryTests.java
@@ -17,8 +17,8 @@
 package org.springframework.guice;
 
 import com.google.inject.Guice;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.context.ApplicationContextException;
@@ -28,11 +28,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class InjectorFactoryTests {
 
 	private static final InjectorFactory injectorFactory = Mockito.mock(InjectorFactory.class);
 
-	@Before
+	@BeforeEach
 	public void init() {
 		Mockito.when(injectorFactory.createInjector(Mockito.anyList())).thenReturn(Guice.createInjector());
 	}
@@ -45,11 +47,13 @@ public class InjectorFactoryTests {
 		context.close();
 	}
 
-	@Test(expected = ApplicationContextException.class)
+	@Test
 	public void testMultipleInjectorFactoriesThrowsApplicationContextException() {
-		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(InjectorFactoryConfig.class,
-				SecondInjectorFactoryConfig.class, ModulesConfig.class);
-		context.close();
+		assertThrows(ApplicationContextException.class, () -> {
+			AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+					InjectorFactoryConfig.class, SecondInjectorFactoryConfig.class, ModulesConfig.class);
+			context.close();
+		});
 	}
 
 	@Configuration

--- a/src/test/java/org/springframework/guice/InjectorFactoryTests.java
+++ b/src/test/java/org/springframework/guice/InjectorFactoryTests.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class InjectorFactoryTests {
 
@@ -49,7 +49,7 @@ public class InjectorFactoryTests {
 
 	@Test
 	public void testMultipleInjectorFactoriesThrowsApplicationContextException() {
-		assertThrows(ApplicationContextException.class, () -> {
+		assertThatExceptionOfType(ApplicationContextException.class).isThrownBy(() -> {
 			AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 					InjectorFactoryConfig.class, SecondInjectorFactoryConfig.class, ModulesConfig.class);
 			context.close();

--- a/src/test/java/org/springframework/guice/JustInTimeBindingTests.java
+++ b/src/test/java/org/springframework/guice/JustInTimeBindingTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
 
 import javax.inject.Inject;

--- a/src/test/java/org/springframework/guice/JustInTimeBindingTests.java
+++ b/src/test/java/org/springframework/guice/JustInTimeBindingTests.java
@@ -27,8 +27,8 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class JustInTimeBindingTests {
 
@@ -40,13 +40,13 @@ public class JustInTimeBindingTests {
 	@Test
 	public void springWithJustInTimeBinding() {
 		System.setProperty("spring.guice.autowireJIT", "true");
-		assertNotNull(springGetFoo());
+		assertThat(springGetFoo()).isNotNull();
 	}
 
 	@Test
 	public void springWithoutJustInTimeBinding() {
 		System.setProperty("spring.guice.autowireJIT", "false");
-		assertThrows(UnsatisfiedDependencyException.class, this::springGetFoo);
+		assertThatExceptionOfType(UnsatisfiedDependencyException.class).isThrownBy(this::springGetFoo);
 	}
 
 	@SuppressWarnings("resource")

--- a/src/test/java/org/springframework/guice/JustInTimeBindingTests.java
+++ b/src/test/java/org/springframework/guice/JustInTimeBindingTests.java
@@ -18,8 +18,8 @@ package org.springframework.guice;
 
 import javax.inject.Inject;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.beans.factory.support.RootBeanDefinition;
@@ -27,11 +27,12 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JustInTimeBindingTests {
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		System.clearProperty("spring.guice.autowireJIT");
 	}
@@ -42,10 +43,10 @@ public class JustInTimeBindingTests {
 		assertNotNull(springGetFoo());
 	}
 
-	@Test(expected = UnsatisfiedDependencyException.class)
+	@Test
 	public void springWithoutJustInTimeBinding() {
 		System.setProperty("spring.guice.autowireJIT", "false");
-		springGetFoo();
+		assertThrows(UnsatisfiedDependencyException.class, this::springGetFoo);
 	}
 
 	@SuppressWarnings("resource")

--- a/src/test/java/org/springframework/guice/LazyInitializationTests.java
+++ b/src/test/java/org/springframework/guice/LazyInitializationTests.java
@@ -1,7 +1,24 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
 
 import com.google.inject.AbstractModule;
 import org.junit.Test;
+
 import org.springframework.aop.support.AopUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -45,7 +62,7 @@ public class LazyInitializationTests {
 	static class TestConfig {
 
 		@Bean
-		public Service service(@Lazy TestBean bean) {
+		Service service(@Lazy TestBean bean) {
 			return new Service(bean);
 		}
 
@@ -55,7 +72,7 @@ public class LazyInitializationTests {
 	static class GuiceConfig {
 
 		@Bean
-		public GuiceModule guiceModule() {
+		GuiceModule guiceModule() {
 			return new GuiceModule();
 		}
 
@@ -65,7 +82,7 @@ public class LazyInitializationTests {
 	static class SpringConfig {
 
 		@Bean
-		public TestBean testBean() {
+		TestBean testBean() {
 			return new TestBean();
 		}
 
@@ -84,12 +101,12 @@ public class LazyInitializationTests {
 
 		private final TestBean bean;
 
-		public Service(TestBean bean) {
+		Service(TestBean bean) {
 			this.bean = bean;
 		}
 
-		public TestBean getBean() {
-			return bean;
+		TestBean getBean() {
+			return this.bean;
 		}
 
 	}

--- a/src/test/java/org/springframework/guice/LazyInitializationTests.java
+++ b/src/test/java/org/springframework/guice/LazyInitializationTests.java
@@ -26,8 +26,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LazyInitializationTests {
 
@@ -40,8 +39,8 @@ public class LazyInitializationTests {
 
 		Service service = context.getBean(Service.class);
 
-		assertTrue(AopUtils.isAopProxy(service.getBean()));
-		assertNotNull(context.getBean(TestBean.class));
+		assertThat(AopUtils.isAopProxy(service.getBean())).isTrue();
+		assertThat(context.getBean(TestBean.class)).isNotNull();
 	}
 
 	@Test
@@ -53,8 +52,8 @@ public class LazyInitializationTests {
 
 		Service service = context.getBean(Service.class);
 
-		assertTrue(AopUtils.isAopProxy(service.getBean()));
-		assertNotNull(context.getBean(TestBean.class));
+		assertThat(AopUtils.isAopProxy(service.getBean())).isTrue();
+		assertThat(context.getBean(TestBean.class)).isNotNull();
 	}
 
 	@Configuration

--- a/src/test/java/org/springframework/guice/LazyInitializationTests.java
+++ b/src/test/java/org/springframework/guice/LazyInitializationTests.java
@@ -17,7 +17,7 @@
 package org.springframework.guice;
 
 import com.google.inject.AbstractModule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.aop.support.AopUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -26,8 +26,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LazyInitializationTests {
 

--- a/src/test/java/org/springframework/guice/MapWiringTests.java
+++ b/src/test/java/org/springframework/guice/MapWiringTests.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test injecting Map
@@ -60,7 +60,7 @@ public class MapWiringTests {
 
 		@Bean
 		Bar foo(Map<String, Foo> foos) {
-			assertFalse(foos.isEmpty());
+			assertThat(foos.isEmpty()).isFalse();
 			return new Bar();
 		}
 

--- a/src/test/java/org/springframework/guice/MapWiringTests.java
+++ b/src/test/java/org/springframework/guice/MapWiringTests.java
@@ -19,14 +19,14 @@ package org.springframework.guice;
 import java.util.Map;
 
 import com.google.inject.AbstractModule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test injecting Map
@@ -60,7 +60,7 @@ public class MapWiringTests {
 
 		@Bean
 		Bar foo(Map<String, Foo> foos) {
-			assertTrue(!foos.isEmpty());
+			assertFalse(foos.isEmpty());
 			return new Bar();
 		}
 

--- a/src/test/java/org/springframework/guice/MapWiringTests.java
+++ b/src/test/java/org/springframework/guice/MapWiringTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
 
 import java.util.Map;

--- a/src/test/java/org/springframework/guice/ModuleFilteringTests.java
+++ b/src/test/java/org/springframework/guice/ModuleFilteringTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
 
 import com.google.inject.AbstractModule;
@@ -11,7 +27,6 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.guice.ModuleFilteringTests.FilterThisModule;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
 
@@ -47,7 +62,7 @@ public class ModuleFilteringTests {
 		}
 	}
 
-	public static interface SomeInterface {
+	public interface SomeInterface {
 
 	}
 
@@ -68,26 +83,26 @@ public class ModuleFilteringTests {
 
 	}
 
-}
+	@EnableGuiceModules
+	@Configuration
+	static class ModuleFilteringTestsConfig {
 
-@EnableGuiceModules
-@Configuration
-class ModuleFilteringTestsConfig {
+		@Bean
+		InjectorFactory injectorFactory() {
+			return (modules) -> Guice.createInjector(Stage.PRODUCTION, modules);
+		}
 
-	@Bean
-	public InjectorFactory injectorFactory() {
-		return modules -> Guice.createInjector(Stage.PRODUCTION, modules);
-	}
+		@Bean
+		Module module() {
+			return new AbstractModule() {
 
-	@Bean
-	public Module module() {
-		return new AbstractModule() {
+				@Override
+				protected void configure() {
+					install(new FilterThisModule());
+				}
+			};
+		}
 
-			@Override
-			protected void configure() {
-				install(new FilterThisModule());
-			}
-		};
 	}
 
 }

--- a/src/test/java/org/springframework/guice/ModuleFilteringTests.java
+++ b/src/test/java/org/springframework/guice/ModuleFilteringTests.java
@@ -20,8 +20,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Module;
 import com.google.inject.Stage;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -30,35 +30,34 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ModuleFilteringTests {
 
-	@AfterClass
+	@AfterAll
 	public static void cleanUp() {
 		System.clearProperty("spring.guice.modules.exclude");
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test
 	public void verifyAllIsWellWhenNoModulesFiltered() {
 		System.setProperty("spring.guice.modules.exclude", "FilterSomeNonExistentModule");
-		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
-				ModuleFilteringTestsConfig.class);
-		SomeInterface someDependency = context.getBean(SomeInterface.class);
-		assertNotNull(someDependency);
-		context.close();
+		assertThrows(RuntimeException.class, () -> {
+			AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+					ModuleFilteringTestsConfig.class);
+			SomeInterface someDependency = context.getBean(SomeInterface.class);
+			assertNotNull(someDependency);
+			context.close();
+		});
 	}
 
-	@Test(expected = NoSuchBeanDefinitionException.class)
+	@Test
 	public void verifyFilteredModuleIsFiltered() {
 		System.setProperty("spring.guice.modules.exclude", "FilterThisModule");
-		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
-				ModuleFilteringTestsConfig.class);
-		try {
-			context.getBean(SomeInterface.class);
-		}
-		finally {
-			context.close();
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				ModuleFilteringTestsConfig.class)) {
+			assertThrows(NoSuchBeanDefinitionException.class, () -> context.getBean(SomeInterface.class));
 		}
 	}
 

--- a/src/test/java/org/springframework/guice/ModuleFilteringTests.java
+++ b/src/test/java/org/springframework/guice/ModuleFilteringTests.java
@@ -30,8 +30,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ModuleFilteringTests {
 
@@ -43,11 +43,11 @@ public class ModuleFilteringTests {
 	@Test
 	public void verifyAllIsWellWhenNoModulesFiltered() {
 		System.setProperty("spring.guice.modules.exclude", "FilterSomeNonExistentModule");
-		assertThrows(RuntimeException.class, () -> {
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> {
 			AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 					ModuleFilteringTestsConfig.class);
 			SomeInterface someDependency = context.getBean(SomeInterface.class);
-			assertNotNull(someDependency);
+			assertThat(someDependency).isNotNull();
 			context.close();
 		});
 	}
@@ -57,7 +57,8 @@ public class ModuleFilteringTests {
 		System.setProperty("spring.guice.modules.exclude", "FilterThisModule");
 		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 				ModuleFilteringTestsConfig.class)) {
-			assertThrows(NoSuchBeanDefinitionException.class, () -> context.getBean(SomeInterface.class));
+			assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+					.isThrownBy(() -> context.getBean(SomeInterface.class));
 		}
 	}
 

--- a/src/test/java/org/springframework/guice/NativeGuiceTests.java
+++ b/src/test/java/org/springframework/guice/NativeGuiceTests.java
@@ -24,7 +24,7 @@ import com.google.inject.Injector;
 import com.google.inject.name.Names;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Dave Syer
@@ -39,7 +39,7 @@ public class NativeGuiceTests {
 	public void test() {
 		Injector app = Guice.createInjector(new TestConfig());
 		NativeGuiceTests instance = app.getInstance(NativeGuiceTests.class);
-		assertNotNull(instance.bar);
+		assertThat(instance.bar).isNotNull();
 	}
 
 	public static class TestConfig extends AbstractModule {

--- a/src/test/java/org/springframework/guice/NativeGuiceTests.java
+++ b/src/test/java/org/springframework/guice/NativeGuiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,15 @@
 
 package org.springframework.guice;
 
-import static org.junit.Assert.assertNotNull;
-
 import javax.inject.Inject;
-
-import org.junit.Test;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.name.Names;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Dave Syer

--- a/src/test/java/org/springframework/guice/NativeGuiceTests.java
+++ b/src/test/java/org/springframework/guice/NativeGuiceTests.java
@@ -22,9 +22,9 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.name.Names;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Dave Syer

--- a/src/test/java/org/springframework/guice/PrivateModuleTests.java
+++ b/src/test/java/org/springframework/guice/PrivateModuleTests.java
@@ -34,9 +34,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class PrivateModuleTests {
 
@@ -59,34 +58,35 @@ public class PrivateModuleTests {
 		Injector injector = context.getBean(Injector.class);
 		SomeInterface injectorProvidedPrivateBinding = injector
 				.getInstance(Key.get(SomeInterface.class, Names.named("exposed")));
-		assertNotNull(injectorProvidedPrivateBinding);
+		assertThat(injectorProvidedPrivateBinding).isNotNull();
 		SomeInterface springProvidedPrivateBinding = context.getBean(SomeInterface.class);
-		assertNotNull(springProvidedPrivateBinding);
+		assertThat(springProvidedPrivateBinding).isNotNull();
 		SomeInterface namedPrivateBinding = BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(),
 				SomeInterface.class, "exposed");
-		assertNotNull(namedPrivateBinding);
-		assertEquals(injectorProvidedPrivateBinding, springProvidedPrivateBinding);
-		assertEquals(injectorProvidedPrivateBinding, namedPrivateBinding);
+		assertThat(namedPrivateBinding).isNotNull();
+		assertThat(springProvidedPrivateBinding).isEqualTo(injectorProvidedPrivateBinding);
+		assertThat(namedPrivateBinding).isEqualTo(injectorProvidedPrivateBinding);
 		String beanDependingOnPrivateBinding = context.getBean("somethingThatWantsAPrivateBinding", String.class);
-		assertNotNull(beanDependingOnPrivateBinding);
-		assertEquals("foo", beanDependingOnPrivateBinding);
+		assertThat(beanDependingOnPrivateBinding).isNotNull();
+		assertThat(beanDependingOnPrivateBinding).isEqualTo("foo");
 	}
 
 	@Test
 	public void verifyPrivateModulesPrivateBindingsAreNotExposedViaInjector() {
 		Injector injector = context.getBean(Injector.class);
-		assertThrows(ConfigurationException.class,
-				() -> injector.getInstance(Key.get(SomeInterface.class, Names.named("notexposed"))));
+		assertThatExceptionOfType(ConfigurationException.class)
+				.isThrownBy(() -> injector.getInstance(Key.get(SomeInterface.class, Names.named("notexposed"))));
 	}
 
 	@Test
 	public void verifyPrivateModulesPrivateBindingsAreNotExposedViaSpring() {
-		assertThrows(NoSuchBeanDefinitionException.class, () -> context.getBean("notexposed", SomeInterface.class));
+		assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+				.isThrownBy(() -> context.getBean("notexposed", SomeInterface.class));
 	}
 
 	@Test
 	public void verifyPrivateModulesPrivateBindingsAreNotExposedViaSpringWithQualifier() {
-		assertThrows(NoSuchBeanDefinitionException.class, () -> BeanFactoryAnnotationUtils
+		assertThatExceptionOfType(NoSuchBeanDefinitionException.class).isThrownBy(() -> BeanFactoryAnnotationUtils
 				.qualifiedBeanOfType(context.getBeanFactory(), SomeInterface.class, "notexposed"));
 	}
 

--- a/src/test/java/org/springframework/guice/PrivateModuleTests.java
+++ b/src/test/java/org/springframework/guice/PrivateModuleTests.java
@@ -1,19 +1,20 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.guice.PrivateModuleTests.SomeInterface;
-import org.springframework.guice.PrivateModuleTests.SomePrivateModule;
-import org.springframework.guice.annotation.EnableGuiceModules;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.ConfigurationException;
@@ -22,6 +23,19 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.name.Names;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.guice.annotation.EnableGuiceModules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class PrivateModuleTests {
 
@@ -73,7 +87,7 @@ public class PrivateModuleTests {
 		BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(), SomeInterface.class, "notexposed");
 	}
 
-	public static interface SomeInterface {
+	public interface SomeInterface {
 
 	}
 
@@ -94,25 +108,25 @@ public class PrivateModuleTests {
 
 	}
 
-}
+	@EnableGuiceModules
+	@Configuration
+	static class PrivateModuleTestConfig {
 
-@EnableGuiceModules
-@Configuration
-class PrivateModuleTestConfig {
+		@Bean
+		String somethingThatWantsAPrivateBinding(SomeInterface privateBinding) {
+			return "foo";
+		}
 
-	@Bean
-	public String somethingThatWantsAPrivateBinding(SomeInterface privateBinding) {
-		return "foo";
-	}
+		@Bean
+		Module module() {
+			return new AbstractModule() {
+				@Override
+				protected void configure() {
+					install(new SomePrivateModule());
+				}
+			};
+		}
 
-	@Bean
-	public Module module() {
-		return new AbstractModule() {
-			@Override
-			protected void configure() {
-				install(new SomePrivateModule());
-			}
-		};
 	}
 
 }

--- a/src/test/java/org/springframework/guice/PrivateModuleTests.java
+++ b/src/test/java/org/springframework/guice/PrivateModuleTests.java
@@ -23,9 +23,9 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.name.Names;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
@@ -34,19 +34,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PrivateModuleTests {
 
 	private static AnnotationConfigApplicationContext context;
 
-	@BeforeClass
+	@BeforeAll
 	public static void init() {
 		context = new AnnotationConfigApplicationContext(PrivateModuleTestConfig.class);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void cleanup() {
 		if (context != null) {
 			context.close();
@@ -71,20 +72,22 @@ public class PrivateModuleTests {
 		assertEquals("foo", beanDependingOnPrivateBinding);
 	}
 
-	@Test(expected = ConfigurationException.class)
+	@Test
 	public void verifyPrivateModulesPrivateBindingsAreNotExposedViaInjector() {
 		Injector injector = context.getBean(Injector.class);
-		injector.getInstance(Key.get(SomeInterface.class, Names.named("notexposed")));
+		assertThrows(ConfigurationException.class,
+				() -> injector.getInstance(Key.get(SomeInterface.class, Names.named("notexposed"))));
 	}
 
-	@Test(expected = NoSuchBeanDefinitionException.class)
+	@Test
 	public void verifyPrivateModulesPrivateBindingsAreNotExposedViaSpring() {
-		context.getBean("notexposed", SomeInterface.class);
+		assertThrows(NoSuchBeanDefinitionException.class, () -> context.getBean("notexposed", SomeInterface.class));
 	}
 
-	@Test(expected = NoSuchBeanDefinitionException.class)
+	@Test
 	public void verifyPrivateModulesPrivateBindingsAreNotExposedViaSpringWithQualifier() {
-		BeanFactoryAnnotationUtils.qualifiedBeanOfType(context.getBeanFactory(), SomeInterface.class, "notexposed");
+		assertThrows(NoSuchBeanDefinitionException.class, () -> BeanFactoryAnnotationUtils
+				.qualifiedBeanOfType(context.getBeanFactory(), SomeInterface.class, "notexposed"));
 	}
 
 	public interface SomeInterface {

--- a/src/test/java/org/springframework/guice/PrototypeScopedBeanTests.java
+++ b/src/test/java/org/springframework/guice/PrototypeScopedBeanTests.java
@@ -29,8 +29,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PrototypeScopedBeanTests {
 
@@ -40,9 +39,9 @@ public class PrototypeScopedBeanTests {
 		Injector injector = context.getBean(Injector.class);
 		GuiceService1 gs1 = injector.getInstance(GuiceService1.class);
 		GuiceService2 gs2 = injector.getInstance((GuiceService2.class));
-		assertNotNull(gs1);
-		assertNotNull(gs2);
-		assertNotEquals(gs1.bean, gs2.bean);
+		assertThat(gs1).isNotNull();
+		assertThat(gs2).isNotNull();
+		assertThat(gs2.bean).isNotEqualTo(gs1.bean);
 	}
 
 	@Configuration

--- a/src/test/java/org/springframework/guice/PrototypeScopedBeanTests.java
+++ b/src/test/java/org/springframework/guice/PrototypeScopedBeanTests.java
@@ -1,15 +1,36 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
+
+import javax.inject.Inject;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import org.junit.Test;
-import org.springframework.context.annotation.*;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import javax.inject.Inject;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class PrototypeScopedBeanTests {
 
@@ -29,7 +50,7 @@ public class PrototypeScopedBeanTests {
 	static class ModulesConfig {
 
 		@Bean
-		public Module guiceModule() {
+		Module guiceModule() {
 			return new AbstractModule() {
 				@Override
 				protected void configure() {
@@ -41,7 +62,7 @@ public class PrototypeScopedBeanTests {
 
 		@Bean
 		@Scope("prototype")
-		public PrototypeBean prototypeBean() {
+		PrototypeBean prototypeBean() {
 			return new PrototypeBean();
 		}
 

--- a/src/test/java/org/springframework/guice/PrototypeScopedBeanTests.java
+++ b/src/test/java/org/springframework/guice/PrototypeScopedBeanTests.java
@@ -21,7 +21,7 @@ import javax.inject.Inject;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Module;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -29,8 +29,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class PrototypeScopedBeanTests {
 

--- a/src/test/java/org/springframework/guice/ProvidesSupplierWiringTests.java
+++ b/src/test/java/org/springframework/guice/ProvidesSupplierWiringTests.java
@@ -24,8 +24,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -55,7 +55,7 @@ public class ProvidesSupplierWiringTests {
 	// ToDo -- Today this direction doesn't work without further work. Ignore the test for
 	// now.
 	@SuppressWarnings("unused")
-	@Ignore
+	@Disabled
 	@Test
 	public void testProvidesSupplierSpring() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(FooBarSpring.class);

--- a/src/test/java/org/springframework/guice/ProvidesSupplierWiringTests.java
+++ b/src/test/java/org/springframework/guice/ProvidesSupplierWiringTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
 
 import java.util.function.Supplier;
@@ -18,7 +34,8 @@ import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.injector.SpringInjector;
 
 /**
- * Test Generics (e.g., Supplier<T>) not losing type info across bridge in both directions
+ * Test Generics (e.g., {@literal Supplier<T>}) not losing type info across bridge in both
+ * directions
  *
  * @author Howard Yuan
  */
@@ -32,6 +49,21 @@ public class ProvidesSupplierWiringTests {
 				FooBar.class);
 		Foo foo = context.getBean(Foo.class);
 		Bar bar = context.getBean(Bar.class);
+	}
+
+	// Test Spring -> Guice direction
+	// ToDo -- Today this direction doesn't work without further work. Ignore the test for
+	// now.
+	@SuppressWarnings("unused")
+	@Ignore
+	@Test
+	public void testProvidesSupplierSpring() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(FooBarSpring.class);
+		SpringInjector injector = new SpringInjector(context);
+		Foo_Spring fooSpring = injector.getInstance(Key.get(new TypeLiteral<Supplier<Foo_Spring>>() {
+		})).get();
+		Bar_Spring barSpring = injector.getInstance(Key.get(new TypeLiteral<Supplier<Bar_Spring>>() {
+		})).get();
 	}
 
 	@Configuration
@@ -86,21 +118,6 @@ public class ProvidesSupplierWiringTests {
 
 	static class Bar {
 
-	}
-
-	// Test Spring -> Guice direction
-	// ToDo -- Today this direction doesn't work without further work. Ignore the test for
-	// now.
-	@SuppressWarnings("unused")
-	@Ignore
-	@Test
-	public void testProvidesSupplierSpring() {
-		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(FooBarSpring.class);
-		SpringInjector injector = new SpringInjector(context);
-		Foo_Spring fooSpring = injector.getInstance(Key.get(new TypeLiteral<Supplier<Foo_Spring>>() {
-		})).get();
-		Bar_Spring barSpring = injector.getInstance(Key.get(new TypeLiteral<Supplier<Bar_Spring>>() {
-		})).get();
 	}
 
 	@Configuration

--- a/src/test/java/org/springframework/guice/ScopingTests.java
+++ b/src/test/java/org/springframework/guice/ScopingTests.java
@@ -21,7 +21,6 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.Scope;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -29,8 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ScopingTests {
 
@@ -40,25 +38,25 @@ public class ScopingTests {
 		SomeSingletonDependency someSingletonDependency1 = context.getBean(SomeSingletonDependency.class);
 		SomeSingletonDependency someSingletonDependency2 = context.getBean(SomeSingletonDependency.class);
 
-		assertNotNull(someSingletonDependency1);
-		assertNotNull(someSingletonDependency2);
-		assertEquals(someSingletonDependency1, someSingletonDependency2);
+		assertThat(someSingletonDependency1).isNotNull();
+		assertThat(someSingletonDependency2).isNotNull();
+		assertThat(someSingletonDependency2).isEqualTo(someSingletonDependency1);
 
 		SomeNoScopeDependency someNoScopeDependency1 = context.getBean(SomeNoScopeDependency.class);
 		SomeNoScopeDependency someNoScopeDependency2 = context.getBean(SomeNoScopeDependency.class);
 
-		assertNotNull(someNoScopeDependency1);
-		assertNotNull(someNoScopeDependency2);
-		Assertions.assertNotEquals(someNoScopeDependency1, someNoScopeDependency2);
+		assertThat(someNoScopeDependency1).isNotNull();
+		assertThat(someNoScopeDependency2).isNotNull();
+		assertThat(someNoScopeDependency2).isNotEqualTo(someNoScopeDependency1);
 
 		SomeCustomScopeDependency someCustomScopeDependency1 = context.getBean(SomeCustomScopeDependency.class);
 		SomeCustomScopeDependency someCustomScopeDependency2 = context.getBean(SomeCustomScopeDependency.class);
 
-		assertNotNull(someCustomScopeDependency1);
-		assertNotNull(someCustomScopeDependency2);
-		Assertions.assertNotEquals(someCustomScopeDependency1, someCustomScopeDependency2);
-		assertEquals(someCustomScopeDependency1.value, "custom");
-		assertEquals(someCustomScopeDependency2.value, "custom");
+		assertThat(someCustomScopeDependency1).isNotNull();
+		assertThat(someCustomScopeDependency2).isNotNull();
+		assertThat(someCustomScopeDependency2).isNotEqualTo(someCustomScopeDependency1);
+		assertThat("custom").isEqualTo(someCustomScopeDependency1.value);
+		assertThat("custom").isEqualTo(someCustomScopeDependency2.value);
 
 		context.close();
 	}

--- a/src/test/java/org/springframework/guice/ScopingTests.java
+++ b/src/test/java/org/springframework/guice/ScopingTests.java
@@ -21,16 +21,16 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.Scope;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ScopingTests {
 
@@ -49,14 +49,14 @@ public class ScopingTests {
 
 		assertNotNull(someNoScopeDependency1);
 		assertNotNull(someNoScopeDependency2);
-		assertNotEquals(someNoScopeDependency1, someNoScopeDependency2);
+		Assertions.assertNotEquals(someNoScopeDependency1, someNoScopeDependency2);
 
 		SomeCustomScopeDependency someCustomScopeDependency1 = context.getBean(SomeCustomScopeDependency.class);
 		SomeCustomScopeDependency someCustomScopeDependency2 = context.getBean(SomeCustomScopeDependency.class);
 
 		assertNotNull(someCustomScopeDependency1);
 		assertNotNull(someCustomScopeDependency2);
-		assertNotEquals(someCustomScopeDependency1, someCustomScopeDependency2);
+		Assertions.assertNotEquals(someCustomScopeDependency1, someCustomScopeDependency2);
 		assertEquals(someCustomScopeDependency1.value, "custom");
 		assertEquals(someCustomScopeDependency2.value, "custom");
 

--- a/src/test/java/org/springframework/guice/ScopingTests.java
+++ b/src/test/java/org/springframework/guice/ScopingTests.java
@@ -1,24 +1,36 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-
-import org.junit.Test;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.guice.ScopingTests.CustomScope;
-import org.springframework.guice.ScopingTests.SomeCustomScopeDependency;
-import org.springframework.guice.ScopingTests.SomeNoScopeDependency;
-import org.springframework.guice.ScopingTests.SomeSingletonDependency;
-import org.springframework.guice.annotation.EnableGuiceModules;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.Scope;
+import org.junit.Test;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.guice.annotation.EnableGuiceModules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class ScopingTests {
 
@@ -76,30 +88,30 @@ public class ScopingTests {
 
 	}
 
-}
+	@EnableGuiceModules
+	@Configuration
+	static class ScopingTestsConfig {
 
-@EnableGuiceModules
-@Configuration
-class ScopingTestsConfig {
+		@Bean
+		Module module() {
+			return new AbstractModule() {
+				@Override
+				protected void configure() {
+					CustomScope customScope = new CustomScope() {
+						@SuppressWarnings("unchecked")
+						@Override
+						public <T> Provider<T> scope(Key<T> key, Provider<T> unscoped) {
+							Provider<?> provider = () -> new SomeCustomScopeDependency("custom");
+							return (Provider<T>) provider;
+						}
+					};
+					bind(SomeSingletonDependency.class).asEagerSingleton();
+					bind(SomeNoScopeDependency.class);
+					bind(SomeCustomScopeDependency.class).in(customScope);
+				}
+			};
+		}
 
-	@Bean
-	public Module module() {
-		return new AbstractModule() {
-			@Override
-			protected void configure() {
-				CustomScope customScope = new CustomScope() {
-					@SuppressWarnings("unchecked")
-					@Override
-					public <T> Provider<T> scope(Key<T> key, Provider<T> unscoped) {
-						Provider<?> provider = () -> new SomeCustomScopeDependency("custom");
-						return (Provider<T>) provider;
-					}
-				};
-				bind(SomeSingletonDependency.class).asEagerSingleton();
-				bind(SomeNoScopeDependency.class);
-				bind(SomeCustomScopeDependency.class).in(customScope);
-			}
-		};
 	}
 
 }

--- a/src/test/java/org/springframework/guice/SimpleWiringTests.java
+++ b/src/test/java/org/springframework/guice/SimpleWiringTests.java
@@ -1,19 +1,35 @@
-package org.springframework.guice;
+/*
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import static org.junit.Assert.assertNotNull;
+package org.springframework.guice;
 
 import javax.inject.Inject;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import org.junit.Test;
+
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.injector.SpringInjector;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
+import static org.junit.Assert.assertNotNull;
 
 public class SimpleWiringTests {
 

--- a/src/test/java/org/springframework/guice/SimpleWiringTests.java
+++ b/src/test/java/org/springframework/guice/SimpleWiringTests.java
@@ -29,14 +29,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.injector.SpringInjector;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleWiringTests {
 
 	@Test
 	public void guiceyFoo() {
 		Injector app = Guice.createInjector(new TestConfig());
-		assertNotNull(app.getInstance(Foo.class));
+		assertThat(app.getInstance(Foo.class)).isNotNull();
 	}
 
 	@Test
@@ -46,7 +46,7 @@ public class SimpleWiringTests {
 				MyService.class);
 		context.getDefaultListableBeanFactory().registerBeanDefinition(Foo.class.getSimpleName(),
 				new RootBeanDefinition(Foo.class));
-		assertNotNull(context.getBean(Foo.class));
+		assertThat(context.getBean(Foo.class)).isNotNull();
 	}
 
 	@Test
@@ -54,7 +54,7 @@ public class SimpleWiringTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestConfig.class,
 				ModulesConfig.class);
 		Injector app = new SpringInjector(context);
-		assertNotNull(app.getInstance(Foo.class));
+		assertThat(app.getInstance(Foo.class)).isNotNull();
 	}
 
 	@Configuration

--- a/src/test/java/org/springframework/guice/SimpleWiringTests.java
+++ b/src/test/java/org/springframework/guice/SimpleWiringTests.java
@@ -21,7 +21,7 @@ import javax.inject.Inject;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.injector.SpringInjector;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SimpleWiringTests {
 

--- a/src/test/java/org/springframework/guice/SpringAutowiredCollectionTests.java
+++ b/src/test/java/org/springframework/guice/SpringAutowiredCollectionTests.java
@@ -1,15 +1,32 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
+
+import java.util.Map;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import org.junit.Test;
+
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.injector.SpringInjector;
-
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,18 +50,18 @@ public class SpringAutowiredCollectionTests {
 	static class TestConfig {
 
 		@Bean
-		public ServicesHolder serviceHolder(Map<String, Service> existingServices,
+		ServicesHolder serviceHolder(Map<String, Service> existingServices,
 				Map<String, NonExistingService> nonExistingServices) {
 			return new ServicesHolder(existingServices, nonExistingServices);
 		}
 
 		@Bean
-		public Service service() {
+		Service service() {
 			return new Service();
 		}
 
 		@Bean
-		public GuiceModule guiceServiceModule() {
+		GuiceModule guiceServiceModule() {
 			return new GuiceModule();
 		}
 
@@ -73,8 +90,7 @@ public class SpringAutowiredCollectionTests {
 
 		final Map<String, NonExistingService> nonExistingServices;
 
-		public ServicesHolder(Map<String, Service> existingServices,
-				Map<String, NonExistingService> nonExistingServices) {
+		ServicesHolder(Map<String, Service> existingServices, Map<String, NonExistingService> nonExistingServices) {
 			this.existingServices = existingServices;
 			this.nonExistingServices = nonExistingServices;
 		}

--- a/src/test/java/org/springframework/guice/SpringAutowiredCollectionTests.java
+++ b/src/test/java/org/springframework/guice/SpringAutowiredCollectionTests.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.injector.SpringInjector;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpringAutowiredCollectionTests {
 
@@ -41,8 +41,8 @@ public class SpringAutowiredCollectionTests {
 
 		ServicesHolder servicesHolder = injector.getInstance(ServicesHolder.class);
 
-		assertEquals(2, servicesHolder.existingServices.size());
-		assertEquals(0, servicesHolder.nonExistingServices.size());
+		assertThat(servicesHolder.existingServices).hasSize(2);
+		assertThat(servicesHolder.nonExistingServices).isEmpty();
 	}
 
 	@Configuration

--- a/src/test/java/org/springframework/guice/SpringAutowiredCollectionTests.java
+++ b/src/test/java/org/springframework/guice/SpringAutowiredCollectionTests.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.injector.SpringInjector;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SpringAutowiredCollectionTests {
 

--- a/src/test/java/org/springframework/guice/SuperClassTests.java
+++ b/src/test/java/org/springframework/guice/SuperClassTests.java
@@ -20,7 +20,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.FactoryBean;
@@ -33,7 +32,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.stereotype.Component;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SuperClassTests {
 
@@ -55,9 +54,9 @@ public class SuperClassTests {
 	@SuppressWarnings("resource")
 	private void baseTestSpringInterface(Class<?> configClass) {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configClass);
-		assertTrue(context.getBean(IParent.class) instanceof IGrandChildImpl);
-		assertTrue(context.getBean(IChild.class) instanceof IGrandChildImpl);
-		assertTrue(context.getBean(IGrandChild.class) instanceof IGrandChildImpl);
+		assertThat(context.getBean(IParent.class) instanceof IGrandChildImpl).isTrue();
+		assertThat(context.getBean(IChild.class) instanceof IGrandChildImpl).isTrue();
+		assertThat(context.getBean(IGrandChild.class) instanceof IGrandChildImpl).isTrue();
 	}
 
 	@Test
@@ -79,9 +78,9 @@ public class SuperClassTests {
 	private void baseTestGuiceInterface(Class<?> configClass) {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configClass);
 		Injector injector = context.getBean(Injector.class);
-		assertTrue(injector.getInstance(IParent.class) instanceof IGrandChildImpl);
-		assertTrue(injector.getInstance(IChild.class) instanceof IGrandChildImpl);
-		assertTrue(injector.getInstance(IGrandChild.class) instanceof IGrandChildImpl);
+		assertThat(injector.getInstance(IParent.class) instanceof IGrandChildImpl).isTrue();
+		assertThat(injector.getInstance(IChild.class) instanceof IGrandChildImpl).isTrue();
+		assertThat(injector.getInstance(IGrandChild.class) instanceof IGrandChildImpl).isTrue();
 	}
 
 	@Test
@@ -104,49 +103,49 @@ public class SuperClassTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configClass);
 
 		String[] allParentBeanNames = context.getBeanNamesForType(IParentWithType.class);
-		Assertions.assertEquals(2, allParentBeanNames.length);
+		assertThat(allParentBeanNames.length).isEqualTo(2);
 
 		String[] stringParentBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IParentWithType.class, String.class));
-		Assertions.assertEquals(1, stringParentBeanNames.length);
-		assertTrue(new TypeLiteral<IGrandChildWithType<String>>() {
-		}.getRawType().isInstance(context.getBean(stringParentBeanNames[0])));
+		assertThat(stringParentBeanNames.length).isEqualTo(1);
+		assertThat(new TypeLiteral<IGrandChildWithType<String>>() {
+		}.getRawType().isInstance(context.getBean(stringParentBeanNames[0]))).isTrue();
 
 		String[] integerParentBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IParentWithType.class, Integer.class));
-		Assertions.assertEquals(1, integerParentBeanNames.length);
-		assertTrue(new TypeLiteral<IGrandChildWithType<Integer>>() {
-		}.getRawType().isInstance(context.getBean(integerParentBeanNames[0])));
+		assertThat(integerParentBeanNames.length).isEqualTo(1);
+		assertThat(new TypeLiteral<IGrandChildWithType<Integer>>() {
+		}.getRawType().isInstance(context.getBean(integerParentBeanNames[0]))).isTrue();
 
 		String[] allChildBeanNames = context.getBeanNamesForType(IChildWithType.class);
-		Assertions.assertEquals(2, allChildBeanNames.length);
+		assertThat(allChildBeanNames.length).isEqualTo(2);
 
 		String[] stringChildBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IChildWithType.class, String.class));
-		Assertions.assertEquals(1, stringChildBeanNames.length);
-		assertTrue(new TypeLiteral<IChildWithType<String>>() {
-		}.getRawType().isInstance(context.getBean(stringChildBeanNames[0])));
+		assertThat(stringChildBeanNames.length).isEqualTo(1);
+		assertThat(new TypeLiteral<IChildWithType<String>>() {
+		}.getRawType().isInstance(context.getBean(stringChildBeanNames[0]))).isTrue();
 
 		String[] integerChildBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IChildWithType.class, Integer.class));
-		Assertions.assertEquals(1, integerChildBeanNames.length);
-		assertTrue(new TypeLiteral<IChildWithType<Integer>>() {
-		}.getRawType().isInstance(context.getBean(integerChildBeanNames[0])));
+		assertThat(integerChildBeanNames.length).isEqualTo(1);
+		assertThat(new TypeLiteral<IChildWithType<Integer>>() {
+		}.getRawType().isInstance(context.getBean(integerChildBeanNames[0]))).isTrue();
 
 		String[] allGrandChildBeanNames = context.getBeanNamesForType(IGrandChildWithType.class);
-		Assertions.assertEquals(2, allGrandChildBeanNames.length);
+		assertThat(allGrandChildBeanNames.length).isEqualTo(2);
 
 		String[] stringGrandChildBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IGrandChildWithType.class, String.class));
-		Assertions.assertEquals(1, stringGrandChildBeanNames.length);
-		assertTrue(new TypeLiteral<IGrandChildWithType<String>>() {
-		}.getRawType().isInstance(context.getBean(stringGrandChildBeanNames[0])));
+		assertThat(stringGrandChildBeanNames.length).isEqualTo(1);
+		assertThat(new TypeLiteral<IGrandChildWithType<String>>() {
+		}.getRawType().isInstance(context.getBean(stringGrandChildBeanNames[0]))).isTrue();
 
 		String[] integerGrandChildBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IGrandChildWithType.class, Integer.class));
-		Assertions.assertEquals(1, integerGrandChildBeanNames.length);
-		assertTrue(new TypeLiteral<IGrandChildWithType<Integer>>() {
-		}.getRawType().isInstance(context.getBean(integerGrandChildBeanNames[0])));
+		assertThat(integerGrandChildBeanNames.length).isEqualTo(1);
+		assertThat(new TypeLiteral<IGrandChildWithType<Integer>>() {
+		}.getRawType().isInstance(context.getBean(integerGrandChildBeanNames[0]))).isTrue();
 
 	}
 
@@ -172,28 +171,28 @@ public class SuperClassTests {
 		IParentWithType<String> iParentString = injector
 				.getInstance(Key.get(new TypeLiteral<IParentWithType<String>>() {
 				}));
-		assertTrue(iParentString instanceof IGrandChildString);
+		assertThat(iParentString instanceof IGrandChildString).isTrue();
 		IParentWithType<Integer> iParentInteger = injector
 				.getInstance(Key.get(new TypeLiteral<IParentWithType<Integer>>() {
 				}));
-		assertTrue(iParentInteger instanceof IGrandChildInteger);
+		assertThat(iParentInteger instanceof IGrandChildInteger).isTrue();
 
 		IChildWithType<String> iChildString = injector.getInstance(Key.get(new TypeLiteral<IChildWithType<String>>() {
 		}));
-		assertTrue(iChildString instanceof IGrandChildString);
+		assertThat(iChildString instanceof IGrandChildString).isTrue();
 		IChildWithType<Integer> iChildInteger = injector
 				.getInstance(Key.get(new TypeLiteral<IChildWithType<Integer>>() {
 				}));
-		assertTrue(iChildInteger instanceof IGrandChildInteger);
+		assertThat(iChildInteger instanceof IGrandChildInteger).isTrue();
 
 		IGrandChildWithType<String> iGrandChildString = injector
 				.getInstance(Key.get(new TypeLiteral<IGrandChildWithType<String>>() {
 				}));
-		assertTrue(iGrandChildString instanceof IGrandChildString);
+		assertThat(iGrandChildString instanceof IGrandChildString).isTrue();
 		IGrandChildWithType<Integer> iGrandChildInteger = injector
 				.getInstance(Key.get(new TypeLiteral<IGrandChildWithType<Integer>>() {
 				}));
-		assertTrue(iGrandChildInteger instanceof IGrandChildInteger);
+		assertThat(iGrandChildInteger instanceof IGrandChildInteger).isTrue();
 	}
 
 	@SuppressWarnings("resource")
@@ -201,11 +200,11 @@ public class SuperClassTests {
 	public void testSpringClass() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ModulesConfig.class);
 		IFoo iFoo = context.getBean(IFoo.class);
-		assertTrue(iFoo instanceof Foo);
-		assertTrue(iFoo instanceof SubFoo);
+		assertThat(iFoo instanceof Foo).isTrue();
+		assertThat(iFoo instanceof SubFoo).isTrue();
 
 		Foo foo = context.getBean(Foo.class);
-		assertTrue(foo instanceof SubFoo);
+		assertThat(foo instanceof SubFoo).isTrue();
 	}
 
 	@Test
@@ -228,11 +227,11 @@ public class SuperClassTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configClass);
 		Injector injector = context.getBean(Injector.class);
 		IFoo iFoo = injector.getInstance(IFoo.class);
-		assertTrue(iFoo instanceof Foo);
-		assertTrue(iFoo instanceof SubFoo);
+		assertThat(iFoo instanceof Foo).isTrue();
+		assertThat(iFoo instanceof SubFoo).isTrue();
 
 		Foo foo = injector.getInstance(Foo.class);
-		assertTrue(foo instanceof SubFoo);
+		assertThat(foo instanceof SubFoo).isTrue();
 	}
 
 	@Test
@@ -255,25 +254,25 @@ public class SuperClassTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configClass);
 		String[] stringBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IFooWithType.class, String.class));
-		Assertions.assertEquals(1, stringBeanNames.length);
-		assertTrue(context.getBean(stringBeanNames[0]) instanceof StringFoo);
-		assertTrue(context.getBean(stringBeanNames[0]) instanceof SubStringFoo);
+		assertThat(stringBeanNames.length).isEqualTo(1);
+		assertThat(context.getBean(stringBeanNames[0]) instanceof StringFoo).isTrue();
+		assertThat(context.getBean(stringBeanNames[0]) instanceof SubStringFoo).isTrue();
 
 		stringBeanNames = context.getBeanNamesForType(StringFoo.class);
-		Assertions.assertEquals(1, stringBeanNames.length);
-		assertTrue(context.getBean(stringBeanNames[0]) instanceof StringFoo);
-		assertTrue(context.getBean(stringBeanNames[0]) instanceof SubStringFoo);
+		assertThat(stringBeanNames.length).isEqualTo(1);
+		assertThat(context.getBean(stringBeanNames[0]) instanceof StringFoo).isTrue();
+		assertThat(context.getBean(stringBeanNames[0]) instanceof SubStringFoo).isTrue();
 
 		String[] integerBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IFooWithType.class, Integer.class));
-		Assertions.assertEquals(1, integerBeanNames.length);
-		assertTrue(context.getBean(integerBeanNames[0]) instanceof IntegerFoo);
-		assertTrue(context.getBean(integerBeanNames[0]) instanceof SubIntegerFoo);
+		assertThat(integerBeanNames.length).isEqualTo(1);
+		assertThat(context.getBean(integerBeanNames[0]) instanceof IntegerFoo).isTrue();
+		assertThat(context.getBean(integerBeanNames[0]) instanceof SubIntegerFoo).isTrue();
 
 		integerBeanNames = context.getBeanNamesForType(IntegerFoo.class);
-		Assertions.assertEquals(1, integerBeanNames.length);
-		assertTrue(context.getBean(integerBeanNames[0]) instanceof IntegerFoo);
-		assertTrue(context.getBean(integerBeanNames[0]) instanceof SubIntegerFoo);
+		assertThat(integerBeanNames.length).isEqualTo(1);
+		assertThat(context.getBean(integerBeanNames[0]) instanceof IntegerFoo).isTrue();
+		assertThat(context.getBean(integerBeanNames[0]) instanceof SubIntegerFoo).isTrue();
 	}
 
 	@Test
@@ -298,20 +297,20 @@ public class SuperClassTests {
 
 		IFooWithType<String> iFooWithTypeString = injector.getInstance(Key.get(new TypeLiteral<IFooWithType<String>>() {
 		}));
-		assertTrue(iFooWithTypeString instanceof StringFoo);
-		assertTrue(iFooWithTypeString instanceof SubStringFoo);
+		assertThat(iFooWithTypeString instanceof StringFoo).isTrue();
+		assertThat(iFooWithTypeString instanceof SubStringFoo).isTrue();
 
 		StringFoo stringFoo = injector.getInstance(StringFoo.class);
-		assertTrue(stringFoo instanceof SubStringFoo);
+		assertThat(stringFoo instanceof SubStringFoo).isTrue();
 
 		IFooWithType<Integer> iFooWithTypeInteger = injector
 				.getInstance(Key.get(new TypeLiteral<IFooWithType<Integer>>() {
 				}));
-		assertTrue(iFooWithTypeInteger instanceof IntegerFoo);
-		assertTrue(iFooWithTypeInteger instanceof SubIntegerFoo);
+		assertThat(iFooWithTypeInteger instanceof IntegerFoo).isTrue();
+		assertThat(iFooWithTypeInteger instanceof SubIntegerFoo).isTrue();
 
 		IntegerFoo integerFoo = injector.getInstance(IntegerFoo.class);
-		assertTrue(integerFoo instanceof SubIntegerFoo);
+		assertThat(integerFoo instanceof SubIntegerFoo).isTrue();
 	}
 
 	@Test
@@ -334,7 +333,7 @@ public class SuperClassTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configClass);
 
 		Bar bar = context.getBean(Bar.class);
-		assertTrue(bar instanceof Bar);
+		assertThat(bar instanceof Bar).isTrue();
 	}
 
 	@Test
@@ -356,7 +355,7 @@ public class SuperClassTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configClass);
 		Injector injector = context.getBean(Injector.class);
 		Bar bar = injector.getInstance(Bar.class);
-		assertTrue(bar instanceof Bar);
+		assertThat(bar instanceof Bar).isTrue();
 	}
 
 	static class DisableJITConfig {

--- a/src/test/java/org/springframework/guice/SuperClassTests.java
+++ b/src/test/java/org/springframework/guice/SuperClassTests.java
@@ -20,7 +20,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -32,8 +33,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.stereotype.Component;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SuperClassTests {
 
@@ -104,47 +104,47 @@ public class SuperClassTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configClass);
 
 		String[] allParentBeanNames = context.getBeanNamesForType(IParentWithType.class);
-		assertEquals(2, allParentBeanNames.length);
+		Assertions.assertEquals(2, allParentBeanNames.length);
 
 		String[] stringParentBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IParentWithType.class, String.class));
-		assertEquals(1, stringParentBeanNames.length);
+		Assertions.assertEquals(1, stringParentBeanNames.length);
 		assertTrue(new TypeLiteral<IGrandChildWithType<String>>() {
 		}.getRawType().isInstance(context.getBean(stringParentBeanNames[0])));
 
 		String[] integerParentBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IParentWithType.class, Integer.class));
-		assertEquals(1, integerParentBeanNames.length);
+		Assertions.assertEquals(1, integerParentBeanNames.length);
 		assertTrue(new TypeLiteral<IGrandChildWithType<Integer>>() {
 		}.getRawType().isInstance(context.getBean(integerParentBeanNames[0])));
 
 		String[] allChildBeanNames = context.getBeanNamesForType(IChildWithType.class);
-		assertEquals(2, allChildBeanNames.length);
+		Assertions.assertEquals(2, allChildBeanNames.length);
 
 		String[] stringChildBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IChildWithType.class, String.class));
-		assertEquals(1, stringChildBeanNames.length);
+		Assertions.assertEquals(1, stringChildBeanNames.length);
 		assertTrue(new TypeLiteral<IChildWithType<String>>() {
 		}.getRawType().isInstance(context.getBean(stringChildBeanNames[0])));
 
 		String[] integerChildBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IChildWithType.class, Integer.class));
-		assertEquals(1, integerChildBeanNames.length);
+		Assertions.assertEquals(1, integerChildBeanNames.length);
 		assertTrue(new TypeLiteral<IChildWithType<Integer>>() {
 		}.getRawType().isInstance(context.getBean(integerChildBeanNames[0])));
 
 		String[] allGrandChildBeanNames = context.getBeanNamesForType(IGrandChildWithType.class);
-		assertEquals(2, allGrandChildBeanNames.length);
+		Assertions.assertEquals(2, allGrandChildBeanNames.length);
 
 		String[] stringGrandChildBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IGrandChildWithType.class, String.class));
-		assertEquals(1, stringGrandChildBeanNames.length);
+		Assertions.assertEquals(1, stringGrandChildBeanNames.length);
 		assertTrue(new TypeLiteral<IGrandChildWithType<String>>() {
 		}.getRawType().isInstance(context.getBean(stringGrandChildBeanNames[0])));
 
 		String[] integerGrandChildBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IGrandChildWithType.class, Integer.class));
-		assertEquals(1, integerGrandChildBeanNames.length);
+		Assertions.assertEquals(1, integerGrandChildBeanNames.length);
 		assertTrue(new TypeLiteral<IGrandChildWithType<Integer>>() {
 		}.getRawType().isInstance(context.getBean(integerGrandChildBeanNames[0])));
 
@@ -255,23 +255,23 @@ public class SuperClassTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(configClass);
 		String[] stringBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IFooWithType.class, String.class));
-		assertEquals(1, stringBeanNames.length);
+		Assertions.assertEquals(1, stringBeanNames.length);
 		assertTrue(context.getBean(stringBeanNames[0]) instanceof StringFoo);
 		assertTrue(context.getBean(stringBeanNames[0]) instanceof SubStringFoo);
 
 		stringBeanNames = context.getBeanNamesForType(StringFoo.class);
-		assertEquals(1, stringBeanNames.length);
+		Assertions.assertEquals(1, stringBeanNames.length);
 		assertTrue(context.getBean(stringBeanNames[0]) instanceof StringFoo);
 		assertTrue(context.getBean(stringBeanNames[0]) instanceof SubStringFoo);
 
 		String[] integerBeanNames = context
 				.getBeanNamesForType(ResolvableType.forClassWithGenerics(IFooWithType.class, Integer.class));
-		assertEquals(1, integerBeanNames.length);
+		Assertions.assertEquals(1, integerBeanNames.length);
 		assertTrue(context.getBean(integerBeanNames[0]) instanceof IntegerFoo);
 		assertTrue(context.getBean(integerBeanNames[0]) instanceof SubIntegerFoo);
 
 		integerBeanNames = context.getBeanNamesForType(IntegerFoo.class);
-		assertEquals(1, integerBeanNames.length);
+		Assertions.assertEquals(1, integerBeanNames.length);
 		assertTrue(context.getBean(integerBeanNames[0]) instanceof IntegerFoo);
 		assertTrue(context.getBean(integerBeanNames[0]) instanceof SubIntegerFoo);
 	}

--- a/src/test/java/org/springframework/guice/SuperClassTests.java
+++ b/src/test/java/org/springframework/guice/SuperClassTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice;
 
 import com.google.inject.AbstractModule;
@@ -346,7 +362,7 @@ public class SuperClassTests {
 	static class DisableJITConfig {
 
 		@Bean
-		public AbstractModule disableJITModule() {
+		AbstractModule disableJITModule() {
 			return new AbstractModule() {
 				@Override
 				protected void configure() {
@@ -362,27 +378,27 @@ public class SuperClassTests {
 	static class ModulesConfig extends DisableJITConfig {
 
 		@Bean
-		public IGrandChild iGrandChild() {
+		IGrandChild iGrandChild() {
 			return new IGrandChildImpl();
 		}
 
 		@Bean
-		public IGrandChildWithType<String> iChildString() {
+		IGrandChildWithType<String> iChildString() {
 			return new IGrandChildString();
 		}
 
 		@Bean
-		public IGrandChildWithType<Integer> iChildInteger() {
+		IGrandChildWithType<Integer> iChildInteger() {
 			return new IGrandChildInteger();
 		}
 
 		@Bean
-		public SubFoo subFoo() {
+		SubFoo subFoo() {
 			return new SubFoo();
 		}
 
 		@Bean
-		public SubStringFoo stringFoo() {
+		SubStringFoo stringFoo() {
 			return new SubStringFoo();
 		}
 

--- a/src/test/java/org/springframework/guice/annotation/EnableGuiceModulesTests.java
+++ b/src/test/java/org/springframework/guice/annotation/EnableGuiceModulesTests.java
@@ -1,14 +1,17 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.annotation;
@@ -18,7 +21,6 @@ import javax.inject.Named;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
-
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import org.junit.After;
@@ -107,7 +109,7 @@ public class EnableGuiceModulesTests {
 
 		@Bean
 		public Foo foo() {
-			return injector.getInstance(Foo.class);
+			return this.injector.getInstance(Foo.class);
 		}
 
 		@Bean

--- a/src/test/java/org/springframework/guice/annotation/EnableGuiceModulesTests.java
+++ b/src/test/java/org/springframework/guice/annotation/EnableGuiceModulesTests.java
@@ -23,8 +23,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Dave Syer
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class EnableGuiceModulesTests {
 
-	@After
+	@AfterEach
 	public void cleanUp() {
 		System.clearProperty("spring.guice.dedup");
 	}

--- a/src/test/java/org/springframework/guice/annotation/EnableGuiceModulesTests.java
+++ b/src/test/java/org/springframework/guice/annotation/EnableGuiceModulesTests.java
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Dave Syer
@@ -49,7 +49,7 @@ public class EnableGuiceModulesTests {
 	@Test
 	public void test() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestConfig.class);
-		assertNotNull(context.getBean(Foo.class));
+		assertThat(context.getBean(Foo.class)).isNotNull();
 		context.close();
 	}
 
@@ -57,28 +57,28 @@ public class EnableGuiceModulesTests {
 	public void testWithDedupFeatureEnabled() {
 		System.setProperty("spring.guice.dedup", "true");
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestConfig.class);
-		assertNotNull(context.getBean(Foo.class));
+		assertThat(context.getBean(Foo.class)).isNotNull();
 		context.close();
 	}
 
 	@Test
 	public void module() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ModuleConfig.class);
-		assertNotNull(context.getBean(Foo.class));
+		assertThat(context.getBean(Foo.class)).isNotNull();
 		context.close();
 	}
 
 	@Test
 	public void moduleBean() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ModuleBeanConfig.class);
-		assertNotNull(context.getBean(Foo.class));
+		assertThat(context.getBean(Foo.class)).isNotNull();
 		context.close();
 	}
 
 	@Test
 	public void testInjectorCreationDoesNotCauseCircularDependencyError() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(MySpringConfig.class);
-		assertNotNull(context.getBean(SpringProvidedBean.class));
+		assertThat(context.getBean(SpringProvidedBean.class)).isNotNull();
 		context.close();
 	}
 

--- a/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationGenericTypeTests.java
+++ b/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationGenericTypeTests.java
@@ -16,13 +16,13 @@
 
 package org.springframework.guice.annotation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class GuiceModuleAnnotationGenericTypeTests {
 

--- a/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationGenericTypeTests.java
+++ b/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationGenericTypeTests.java
@@ -22,14 +22,14 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GuiceModuleAnnotationGenericTypeTests {
 
 	@Test
 	public void testBinding() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestConfig.class);
-		assertNotNull(context.getBean(Foo.class));
+		assertThat(context.getBean(Foo.class)).isNotNull();
 		context.close();
 	}
 

--- a/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationGenericTypeTests.java
+++ b/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationGenericTypeTests.java
@@ -1,26 +1,37 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.annotation;
 
-import static org.junit.Assert.assertNotNull;
-
 import org.junit.Test;
+
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static org.junit.Assert.assertNotNull;
+
 public class GuiceModuleAnnotationGenericTypeTests {
+
+	@Test
+	public void testBinding() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestConfig.class);
+		assertNotNull(context.getBean(Foo.class));
+		context.close();
+	}
 
 	public interface Foo<T> {
 
@@ -38,7 +49,7 @@ public class GuiceModuleAnnotationGenericTypeTests {
 
 		@Override
 		public T getValue() {
-			return payload;
+			return this.payload;
 		}
 
 	}
@@ -49,17 +60,10 @@ public class GuiceModuleAnnotationGenericTypeTests {
 	static class TestConfig {
 
 		@Bean
-		public FooImpl<String> fooBean() {
+		FooImpl<String> fooBean() {
 			return new FooImpl<String>("foo.foo.foo");
 		}
 
-	}
-
-	@Test
-	public void testBinding() {
-		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestConfig.class);
-		assertNotNull(context.getBean(Foo.class));
-		context.close();
 	}
 
 }

--- a/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationTests.java
+++ b/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationTests.java
@@ -32,8 +32,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.guice.module.SpringModule;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Dave Syer
@@ -44,44 +44,44 @@ public class GuiceModuleAnnotationTests {
 	@Test
 	public void includes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataIncludesConfig.class);
-		assertNotNull(injector.getBinding(Service.class));
+		assertThat(injector.getBinding(Service.class)).isNotNull();
 	}
 
 	@Test
 	public void includesNames() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataIncludeNamesConfig.class);
-		assertNotNull(injector.getBinding(Service.class));
+		assertThat(injector.getBinding(Service.class)).isNotNull();
 	}
 
 	@Test
 	public void includesPatterns() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataIncludePatternsConfig.class);
-		assertNotNull(injector.getBinding(Service.class));
+		assertThat(injector.getBinding(Service.class)).isNotNull();
 	}
 
 	@Test
 	public void excludes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataExcludesConfig.class);
-		assertThrows(ConfigurationException.class, () -> injector.getInstance(Service.class));
+		assertThatExceptionOfType(ConfigurationException.class).isThrownBy(() -> injector.getInstance(Service.class));
 	}
 
 	@Test
 	public void excludesNames() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataExcludeNamesConfig.class);
-		assertThrows(ConfigurationException.class, () -> injector.getBinding(Service.class));
+		assertThatExceptionOfType(ConfigurationException.class).isThrownBy(() -> injector.getBinding(Service.class));
 	}
 
 	@Test
 	public void excludesPatterns() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataExcludePatternsConfig.class);
-		assertThrows(ConfigurationException.class, () -> injector.getBinding(Service.class));
+		assertThatExceptionOfType(ConfigurationException.class).isThrownBy(() -> injector.getBinding(Service.class));
 	}
 
 	@Test
 	public void twoIncludes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataIncludesConfig.class,
 				MetadataMoreIncludesConfig.class);
-		assertNotNull(injector.getBinding(Service.class));
+		assertThat(injector.getBinding(Service.class)).isNotNull();
 	}
 
 	private Injector createInjector(Class<?>... config) {

--- a/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationTests.java
+++ b/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationTests.java
@@ -22,9 +22,7 @@ import java.util.Map;
 import com.google.inject.ConfigurationException;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -34,17 +32,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.guice.module.SpringModule;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Dave Syer
  *
  */
 public class GuiceModuleAnnotationTests {
-
-	@Rule
-	public ExpectedException expected = ExpectedException.none();
 
 	@Test
 	public void includes() throws Exception {
@@ -67,20 +62,19 @@ public class GuiceModuleAnnotationTests {
 	@Test
 	public void excludes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataExcludesConfig.class);
-		this.expected.expect(ConfigurationException.class);
-		assertNull(injector.getInstance(Service.class));
+		assertThrows(ConfigurationException.class, () -> injector.getInstance(Service.class));
 	}
 
-	@Test(expected = ConfigurationException.class)
+	@Test
 	public void excludesNames() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataExcludeNamesConfig.class);
-		injector.getBinding(Service.class);
+		assertThrows(ConfigurationException.class, () -> injector.getBinding(Service.class));
 	}
 
-	@Test(expected = ConfigurationException.class)
+	@Test
 	public void excludesPatterns() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataExcludePatternsConfig.class);
-		injector.getBinding(Service.class);
+		assertThrows(ConfigurationException.class, () -> injector.getBinding(Service.class));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationTests.java
+++ b/src/test/java/org/springframework/guice/annotation/GuiceModuleAnnotationTests.java
@@ -1,27 +1,31 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.annotation;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.inject.ConfigurationException;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -30,9 +34,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.guice.module.SpringModule;
 
-import com.google.inject.ConfigurationException;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Dave Syer
@@ -64,7 +67,7 @@ public class GuiceModuleAnnotationTests {
 	@Test
 	public void excludes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataExcludesConfig.class);
-		expected.expect(ConfigurationException.class);
+		this.expected.expect(ConfigurationException.class);
 		assertNull(injector.getInstance(Service.class));
 	}
 

--- a/src/test/java/org/springframework/guice/annotation/ModuleBeanWiringTests.java
+++ b/src/test/java/org/springframework/guice/annotation/ModuleBeanWiringTests.java
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.AbstractCompleteWiringTests;
 import org.springframework.guice.injector.SpringInjector;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Dave Syer
@@ -52,7 +52,7 @@ public class ModuleBeanWiringTests extends AbstractCompleteWiringTests {
 
 	@Test
 	public void bindToSpringBeanFromGuiceModule() throws Exception {
-		assertNotNull(this.context.getBean(Spam.class));
+		assertThat(this.context.getBean(Spam.class)).isNotNull();
 	}
 
 	@EnableGuiceModules

--- a/src/test/java/org/springframework/guice/annotation/ModuleBeanWiringTests.java
+++ b/src/test/java/org/springframework/guice/annotation/ModuleBeanWiringTests.java
@@ -1,25 +1,30 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.annotation;
-
-import static org.junit.Assert.assertNotNull;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
 import org.junit.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -27,9 +32,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.AbstractCompleteWiringTests;
 import org.springframework.guice.injector.SpringInjector;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Injector;
-import com.google.inject.Provides;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Dave Syer

--- a/src/test/java/org/springframework/guice/annotation/ModuleBeanWiringTests.java
+++ b/src/test/java/org/springframework/guice/annotation/ModuleBeanWiringTests.java
@@ -23,7 +23,7 @@ import javax.inject.Singleton;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.AbstractCompleteWiringTests;
 import org.springframework.guice.injector.SpringInjector;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Dave Syer

--- a/src/test/java/org/springframework/guice/annotation/ModuleNamedBeanWiringTests.java
+++ b/src/test/java/org/springframework/guice/annotation/ModuleNamedBeanWiringTests.java
@@ -1,25 +1,30 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.annotation;
-
-import static org.junit.Assert.assertNotNull;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
 import org.junit.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -27,9 +32,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.AbstractCompleteWiringTests;
 import org.springframework.guice.injector.SpringInjector;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Injector;
-import com.google.inject.Provides;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Dave Syer

--- a/src/test/java/org/springframework/guice/annotation/ModuleNamedBeanWiringTests.java
+++ b/src/test/java/org/springframework/guice/annotation/ModuleNamedBeanWiringTests.java
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.AbstractCompleteWiringTests;
 import org.springframework.guice.injector.SpringInjector;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Dave Syer
@@ -52,7 +52,7 @@ public class ModuleNamedBeanWiringTests extends AbstractCompleteWiringTests {
 
 	@Test
 	public void bindToSpringBeanFromGuiceModule() throws Exception {
-		assertNotNull(this.context.getBean(Spam.class));
+		assertThat(this.context.getBean(Spam.class)).isNotNull();
 	}
 
 	@EnableGuiceModules

--- a/src/test/java/org/springframework/guice/annotation/ModuleNamedBeanWiringTests.java
+++ b/src/test/java/org/springframework/guice/annotation/ModuleNamedBeanWiringTests.java
@@ -23,7 +23,7 @@ import javax.inject.Singleton;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.AbstractCompleteWiringTests;
 import org.springframework.guice.injector.SpringInjector;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Dave Syer

--- a/src/test/java/org/springframework/guice/injector/SpringInjectorTests.java
+++ b/src/test/java/org/springframework/guice/injector/SpringInjectorTests.java
@@ -1,23 +1,28 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.springframework.guice.injector;
 
-import static org.junit.Assert.assertNotNull;
-
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -27,8 +32,7 @@ import org.springframework.guice.AbstractCompleteWiringTests.Baz;
 import org.springframework.guice.AbstractCompleteWiringTests.MyService;
 import org.springframework.guice.AbstractCompleteWiringTests.Service;
 
-import com.google.inject.Key;
-import com.google.inject.name.Names;
+import static org.junit.Assert.assertNotNull;
 
 public class SpringInjectorTests {
 
@@ -41,37 +45,37 @@ public class SpringInjectorTests {
 
 	@After
 	public void close() {
-		if (context != null) {
-			context.close();
+		if (this.context != null) {
+			this.context.close();
 		}
 	}
 
 	@Test
 	public void instance() {
-		assertNotNull(injector.getInstance(Service.class));
+		assertNotNull(this.injector.getInstance(Service.class));
 	}
 
 	@Test
 	public void multiple() {
-		injector = new SpringInjector(create(Additional.class));
-		expected.expect(NoUniqueBeanDefinitionException.class);
-		assertNotNull(injector.getInstance(Service.class));
+		this.injector = new SpringInjector(create(Additional.class));
+		this.expected.expect(NoUniqueBeanDefinitionException.class);
+		assertNotNull(this.injector.getInstance(Service.class));
 	}
 
 	@Test
 	public void named() {
-		injector = new SpringInjector(create(Additional.class));
-		assertNotNull(injector.getInstance(Key.get(Service.class, Names.named("service"))));
+		this.injector = new SpringInjector(create(Additional.class));
+		assertNotNull(this.injector.getInstance(Key.get(Service.class, Names.named("service"))));
 	}
 
 	@Test
 	public void provider() {
-		assertNotNull(injector.getProvider(Service.class).get());
+		assertNotNull(this.injector.getProvider(Service.class).get());
 	}
 
 	@Test
 	public void bindNewObject() {
-		assertNotNull(injector.getInstance(Baz.class));
+		assertNotNull(this.injector.getInstance(Baz.class));
 	}
 
 	private ApplicationContext create(Class<?>... config) {

--- a/src/test/java/org/springframework/guice/injector/SpringInjectorTests.java
+++ b/src/test/java/org/springframework/guice/injector/SpringInjectorTests.java
@@ -30,8 +30,8 @@ import org.springframework.guice.AbstractCompleteWiringTests.Baz;
 import org.springframework.guice.AbstractCompleteWiringTests.MyService;
 import org.springframework.guice.AbstractCompleteWiringTests.Service;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class SpringInjectorTests {
 
@@ -48,29 +48,30 @@ public class SpringInjectorTests {
 
 	@Test
 	public void instance() {
-		assertNotNull(this.injector.getInstance(Service.class));
+		assertThat(this.injector.getInstance(Service.class)).isNotNull();
 	}
 
 	@Test
 	public void multiple() {
 		this.injector = new SpringInjector(create(Additional.class));
-		assertThrows(NoUniqueBeanDefinitionException.class, () -> this.injector.getInstance(Service.class));
+		assertThatExceptionOfType(NoUniqueBeanDefinitionException.class)
+				.isThrownBy(() -> this.injector.getInstance(Service.class));
 	}
 
 	@Test
 	public void named() {
 		this.injector = new SpringInjector(create(Additional.class));
-		assertNotNull(this.injector.getInstance(Key.get(Service.class, Names.named("service"))));
+		assertThat(this.injector.getInstance(Key.get(Service.class, Names.named("service")))).isNotNull();
 	}
 
 	@Test
 	public void provider() {
-		assertNotNull(this.injector.getProvider(Service.class).get());
+		assertThat(this.injector.getProvider(Service.class).get()).isNotNull();
 	}
 
 	@Test
 	public void bindNewObject() {
-		assertNotNull(this.injector.getInstance(Baz.class));
+		assertThat(this.injector.getInstance(Baz.class)).isNotNull();
 	}
 
 	private ApplicationContext create(Class<?>... config) {

--- a/src/test/java/org/springframework/guice/injector/SpringInjectorTests.java
+++ b/src/test/java/org/springframework/guice/injector/SpringInjectorTests.java
@@ -18,10 +18,8 @@ package org.springframework.guice.injector;
 
 import com.google.inject.Key;
 import com.google.inject.name.Names;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
@@ -32,18 +30,16 @@ import org.springframework.guice.AbstractCompleteWiringTests.Baz;
 import org.springframework.guice.AbstractCompleteWiringTests.MyService;
 import org.springframework.guice.AbstractCompleteWiringTests.Service;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SpringInjectorTests {
-
-	@Rule
-	public ExpectedException expected = ExpectedException.none();
 
 	private SpringInjector injector = new SpringInjector(create());
 
 	private AnnotationConfigApplicationContext context;
 
-	@After
+	@AfterEach
 	public void close() {
 		if (this.context != null) {
 			this.context.close();
@@ -58,8 +54,7 @@ public class SpringInjectorTests {
 	@Test
 	public void multiple() {
 		this.injector = new SpringInjector(create(Additional.class));
-		this.expected.expect(NoUniqueBeanDefinitionException.class);
-		assertNotNull(this.injector.getInstance(Service.class));
+		assertThrows(NoUniqueBeanDefinitionException.class, () -> this.injector.getInstance(Service.class));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/guice/injector/SpringWiringTests.java
+++ b/src/test/java/org/springframework/guice/injector/SpringWiringTests.java
@@ -1,24 +1,27 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.injector;
+
+import com.google.inject.Injector;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.AbstractCompleteWiringTests;
-
-import com.google.inject.Injector;
 
 /**
  * @author Dave Syer

--- a/src/test/java/org/springframework/guice/module/DevelepmentStageInjectorTest.java
+++ b/src/test/java/org/springframework/guice/module/DevelepmentStageInjectorTest.java
@@ -35,8 +35,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DevelepmentStageInjectorTest {
 
@@ -55,9 +54,9 @@ public class DevelepmentStageInjectorTest {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 				DevelepmentStageInjectorTest.ModulesConfig.class);
 		TestGuiceModule testGuiceModule = context.getBean(TestGuiceModule.class);
-		assertFalse(testGuiceModule.getProviderExecuted());
+		assertThat(testGuiceModule.getProviderExecuted()).isFalse();
 		GuiceToken guiceToken = context.getBean(GuiceToken.class);
-		assertTrue(testGuiceModule.getProviderExecuted());
+		assertThat(testGuiceModule.getProviderExecuted()).isTrue();
 		context.close();
 	}
 

--- a/src/test/java/org/springframework/guice/module/DevelepmentStageInjectorTest.java
+++ b/src/test/java/org/springframework/guice/module/DevelepmentStageInjectorTest.java
@@ -1,17 +1,39 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.guice.module;
 
-import com.google.inject.*;
+import java.util.List;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.Stage;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
-
-import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -44,12 +66,12 @@ public class DevelepmentStageInjectorTest {
 	static class ModulesConfig {
 
 		@Bean
-		public TestGuiceModule testGuiceModule() {
+		TestGuiceModule testGuiceModule() {
 			return new TestGuiceModule();
 		}
 
 		@Bean
-		public InjectorFactory injectorFactory() {
+		InjectorFactory injectorFactory() {
 			return new TestDevelopmentStageInjectorFactory();
 		}
 
@@ -59,7 +81,7 @@ public class DevelepmentStageInjectorTest {
 
 		private boolean providerExecuted = false;
 
-		public boolean getProviderExecuted() {
+		boolean getProviderExecuted() {
 			return this.providerExecuted;
 		}
 
@@ -69,7 +91,7 @@ public class DevelepmentStageInjectorTest {
 
 		@Provides
 		@Singleton
-		public GuiceToken guiceToken() {
+		GuiceToken guiceToken() {
 			this.providerExecuted = true;
 			return new GuiceToken();
 		}

--- a/src/test/java/org/springframework/guice/module/DevelepmentStageInjectorTest.java
+++ b/src/test/java/org/springframework/guice/module/DevelepmentStageInjectorTest.java
@@ -25,9 +25,9 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.Stage;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -35,17 +35,17 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 import org.springframework.guice.annotation.InjectorFactory;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DevelepmentStageInjectorTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void init() {
 		System.setProperty("spring.guice.stage", "DEVELOPMENT");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void cleanup() {
 		System.clearProperty("spring.guice.stage");
 	}

--- a/src/test/java/org/springframework/guice/module/SpringModuleGuiceBindingAwareTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleGuiceBindingAwareTests.java
@@ -1,15 +1,19 @@
 /*
  * Copyright 2016-2017 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.springframework.guice.module;
 
 import javax.inject.Inject;
@@ -19,7 +23,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import com.google.inject.util.Providers;
-
 import org.junit.Test;
 
 import org.springframework.context.ApplicationEvent;
@@ -79,12 +82,12 @@ public class SpringModuleGuiceBindingAwareTests {
 	static class GuiceProjectWithSpringLibraryTestSpringConfig {
 
 		@Bean
-		public ISpringBean springDefinedSomething(IGuiceDependency1 dependency) {
+		ISpringBean springDefinedSomething(IGuiceDependency1 dependency) {
 			return new SpringBean(dependency);
 		}
 
 		@Bean
-		public ApplicationListener<ApplicationEvent> eventListener(final IGuiceDependency1 dependency) {
+		ApplicationListener<ApplicationEvent> eventListener(final IGuiceDependency1 dependency) {
 			return new ApplicationListener<ApplicationEvent>() {
 				@Override
 				public void onApplicationEvent(ApplicationEvent event) {
@@ -95,17 +98,17 @@ public class SpringModuleGuiceBindingAwareTests {
 
 	}
 
-	static interface IGuiceDependency1 {
+	interface IGuiceDependency1 {
 
 		String doWork();
 
 	}
 
-	static interface IGuiceDependency2 {
+	interface IGuiceDependency2 {
 
 	}
 
-	static interface IGuiceDependency3 {
+	interface IGuiceDependency3 {
 
 	}
 
@@ -118,7 +121,7 @@ public class SpringModuleGuiceBindingAwareTests {
 
 	}
 
-	static interface ISpringBean {
+	interface ISpringBean {
 
 		IGuiceDependency1 getDep1();
 
@@ -139,23 +142,23 @@ public class SpringModuleGuiceBindingAwareTests {
 		private IGuiceDependency3 dep3;
 
 		@Inject
-		public SpringBean(IGuiceDependency1 dependency) {
+		SpringBean(IGuiceDependency1 dependency) {
 			this.dep1 = dependency;
 		}
 
 		@Override
 		public IGuiceDependency1 getDep1() {
-			return dep1;
+			return this.dep1;
 		}
 
 		@Override
 		public IGuiceDependency2 getDep2() {
-			return dep2;
+			return this.dep2;
 		}
 
 		@Override
 		public IGuiceDependency3 getDep3() {
-			return dep3;
+			return this.dep3;
 		}
 
 	}

--- a/src/test/java/org/springframework/guice/module/SpringModuleGuiceBindingAwareTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleGuiceBindingAwareTests.java
@@ -23,7 +23,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import com.google.inject.util.Providers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
@@ -31,9 +31,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.util.AopTestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class SpringModuleGuiceBindingAwareTests {
 
@@ -57,9 +57,12 @@ public class SpringModuleGuiceBindingAwareTests {
 		assertEquals("done", springBean.getDep1().doWork());
 
 		// check binding equality
-		assertSame(injector.getInstance(IGuiceDependency1.class), AopTestUtils.getTargetObject(springBean.getDep1()));
-		assertSame(injector.getInstance(IGuiceDependency2.class), AopTestUtils.getTargetObject(springBean.getDep2()));
-		assertSame(injector.getInstance(IGuiceDependency3.class), AopTestUtils.getTargetObject(springBean.getDep3()));
+		assertSame(injector.getInstance(IGuiceDependency1.class),
+				AopTestUtils.getTargetObject(springBean.getDep1()));
+		assertSame(injector.getInstance(IGuiceDependency2.class),
+				AopTestUtils.getTargetObject(springBean.getDep2()));
+		assertSame(injector.getInstance(IGuiceDependency3.class),
+				AopTestUtils.getTargetObject(springBean.getDep3()));
 	}
 
 	static class SimpleGuiceModule extends AbstractModule {

--- a/src/test/java/org/springframework/guice/module/SpringModuleGuiceBindingAwareTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleGuiceBindingAwareTests.java
@@ -31,9 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.util.AopTestUtils;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpringModuleGuiceBindingAwareTests {
 
@@ -43,26 +41,26 @@ public class SpringModuleGuiceBindingAwareTests {
 				new SpringModule(BeanFactoryProvider.from(GuiceProjectWithSpringLibraryTestSpringConfig.class)));
 
 		// check guice provided bindings
-		assertNotNull(injector.getInstance(GuiceDependency1.class));
-		assertNotNull(injector.getInstance(IGuiceDependency1.class));
+		assertThat(injector.getInstance(GuiceDependency1.class)).isNotNull();
+		assertThat(injector.getInstance(IGuiceDependency1.class)).isNotNull();
 
 		// check spring bindings as interface
 		ISpringBean springBean = injector.getInstance(ISpringBean.class);
-		assertNotNull(springBean);
-		assertNotNull(springBean.getDep1());
-		assertNotNull(springBean.getDep2());
-		assertNotNull(springBean.getDep3());
+		assertThat(springBean).isNotNull();
+		assertThat(springBean.getDep1()).isNotNull();
+		assertThat(springBean.getDep2()).isNotNull();
+		assertThat(springBean.getDep3()).isNotNull();
 
 		// invoke a method to make sure we aren't dealing with a lazy proxy
-		assertEquals("done", springBean.getDep1().doWork());
+		assertThat(springBean.getDep1().doWork()).isEqualTo("done");
 
 		// check binding equality
-		assertSame(injector.getInstance(IGuiceDependency1.class),
-				AopTestUtils.getTargetObject(springBean.getDep1()));
-		assertSame(injector.getInstance(IGuiceDependency2.class),
-				AopTestUtils.getTargetObject(springBean.getDep2()));
-		assertSame(injector.getInstance(IGuiceDependency3.class),
-				AopTestUtils.getTargetObject(springBean.getDep3()));
+		assertThat(injector.getInstance(IGuiceDependency1.class))
+				.isSameAs(AopTestUtils.getTargetObject(springBean.getDep1()));
+		assertThat(injector.getInstance(IGuiceDependency2.class))
+				.isSameAs(AopTestUtils.getTargetObject(springBean.getDep2()));
+		assertThat(injector.getInstance(IGuiceDependency3.class))
+				.isSameAs(AopTestUtils.getTargetObject(springBean.getDep3()));
 	}
 
 	static class SimpleGuiceModule extends AbstractModule {

--- a/src/test/java/org/springframework/guice/module/SpringModuleMetadataTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleMetadataTests.java
@@ -1,35 +1,22 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.module;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import javax.inject.Inject;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-import org.springframework.core.type.filter.AnnotationTypeFilter;
-import org.springframework.core.type.filter.AssignableTypeFilter;
-import org.springframework.guice.module.GuiceModuleMetadata;
-import org.springframework.guice.module.SpringModule;
 
 import com.google.inject.ConfigurationException;
 import com.google.inject.Guice;
@@ -37,6 +24,20 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.ProvisionException;
 import com.google.inject.name.Names;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Dave Syer
@@ -56,7 +57,7 @@ public class SpringModuleMetadataTests {
 	@Test
 	public void twoServices() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MoreConfig.class);
-		expected.expect(ProvisionException.class);
+		this.expected.expect(ProvisionException.class);
 		assertNotNull(injector.getInstance(Service.class));
 	}
 
@@ -75,14 +76,14 @@ public class SpringModuleMetadataTests {
 	@Test
 	public void includes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataIncludesConfig.class);
-		expected.expect(ConfigurationException.class);
+		this.expected.expect(ConfigurationException.class);
 		assertNull(injector.getBinding(Service.class));
 	}
 
 	@Test
 	public void excludes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataExcludesConfig.class);
-		expected.expect(ConfigurationException.class);
+		this.expected.expect(ConfigurationException.class);
 		assertNull(injector.getInstance(Service.class));
 	}
 

--- a/src/test/java/org/springframework/guice/module/SpringModuleMetadataTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleMetadataTests.java
@@ -24,7 +24,6 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.ProvisionException;
 import com.google.inject.name.Names;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cache.annotation.Cacheable;
@@ -35,8 +34,8 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.core.type.filter.AssignableTypeFilter;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Dave Syer
@@ -47,37 +46,40 @@ public class SpringModuleMetadataTests {
 	@Test
 	public void twoConfigClasses() throws Exception {
 		Injector injector = createInjector(TestConfig.class, OtherConfig.class);
-		assertNotNull(injector.getInstance(Service.class));
+		assertThat(injector.getInstance(Service.class)).isNotNull();
 	}
 
 	@Test
 	public void twoServices() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MoreConfig.class);
-		assertThrows(ProvisionException.class, () -> assertNotNull(injector.getInstance(Service.class)));
+		assertThatExceptionOfType(ProvisionException.class)
+				.isThrownBy(() -> assertThat(injector.getInstance(Service.class)).isNotNull());
 	}
 
 	@Test
 	public void twoServicesOnePrimary() throws Exception {
 		Injector injector = createInjector(TestConfig.class, PrimaryConfig.class);
-		assertNotNull(injector.getInstance(Service.class));
+		assertThat(injector.getInstance(Service.class)).isNotNull();
 	}
 
 	@Test
 	public void twoServicesByName() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MoreConfig.class);
-		assertNotNull(injector.getInstance(Key.get(Service.class, Names.named("service"))));
+		assertThat(injector.getInstance(Key.get(Service.class, Names.named("service")))).isNotNull();
 	}
 
 	@Test
 	public void includes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataIncludesConfig.class);
-		assertThrows(ConfigurationException.class, () -> Assertions.assertNull(injector.getBinding(Service.class)));
+		assertThatExceptionOfType(ConfigurationException.class)
+				.isThrownBy(() -> assertThat(injector.getBinding(Service.class)).isNull());
 	}
 
 	@Test
 	public void excludes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataExcludesConfig.class);
-		assertThrows(ConfigurationException.class, () -> Assertions.assertNull(injector.getBinding(Service.class)));
+		assertThatExceptionOfType(ConfigurationException.class)
+				.isThrownBy(() -> assertThat(injector.getBinding(Service.class)).isNull());
 	}
 
 	private Injector createInjector(Class<?>... config) {

--- a/src/test/java/org/springframework/guice/module/SpringModuleMetadataTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleMetadataTests.java
@@ -24,9 +24,8 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.ProvisionException;
 import com.google.inject.name.Names;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -36,17 +35,14 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.core.type.filter.AssignableTypeFilter;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Dave Syer
  *
  */
 public class SpringModuleMetadataTests {
-
-	@Rule
-	public ExpectedException expected = ExpectedException.none();
 
 	@Test
 	public void twoConfigClasses() throws Exception {
@@ -57,8 +53,7 @@ public class SpringModuleMetadataTests {
 	@Test
 	public void twoServices() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MoreConfig.class);
-		this.expected.expect(ProvisionException.class);
-		assertNotNull(injector.getInstance(Service.class));
+		assertThrows(ProvisionException.class, () -> assertNotNull(injector.getInstance(Service.class)));
 	}
 
 	@Test
@@ -76,15 +71,13 @@ public class SpringModuleMetadataTests {
 	@Test
 	public void includes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataIncludesConfig.class);
-		this.expected.expect(ConfigurationException.class);
-		assertNull(injector.getBinding(Service.class));
+		assertThrows(ConfigurationException.class, () -> Assertions.assertNull(injector.getBinding(Service.class)));
 	}
 
 	@Test
 	public void excludes() throws Exception {
 		Injector injector = createInjector(TestConfig.class, MetadataExcludesConfig.class);
-		this.expected.expect(ConfigurationException.class);
-		assertNull(injector.getInstance(Service.class));
+		assertThrows(ConfigurationException.class, () -> Assertions.assertNull(injector.getBinding(Service.class)));
 	}
 
 	private Injector createInjector(Class<?>... config) {

--- a/src/test/java/org/springframework/guice/module/SpringModuleWiringTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleWiringTests.java
@@ -1,18 +1,23 @@
 /*
  * Copyright 2013-2014 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.guice.module;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 
@@ -20,9 +25,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.AbstractCompleteWiringTests;
-
-import com.google.inject.Guice;
-import com.google.inject.Injector;
 
 /**
  * @author Dave Syer

--- a/src/test/java/org/springframework/guice/module/SpringModuleWiringTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleWiringTests.java
@@ -18,8 +18,6 @@ package org.springframework.guice.module;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -31,9 +29,6 @@ import org.springframework.guice.AbstractCompleteWiringTests;
  *
  */
 public class SpringModuleWiringTests extends AbstractCompleteWiringTests {
-
-	@Rule
-	public ExpectedException expected = ExpectedException.none();
 
 	@Override
 	protected Injector createInjector() {

--- a/src/test/java/org/springframework/guice/module/SpringModuleWrappedTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleWrappedTests.java
@@ -22,13 +22,13 @@ import javax.inject.Named;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SpringModuleWrappedTests {
 

--- a/src/test/java/org/springframework/guice/module/SpringModuleWrappedTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleWrappedTests.java
@@ -1,15 +1,19 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.springframework.guice.module;
 
 import javax.inject.Inject;
@@ -18,7 +22,6 @@ import javax.inject.Named;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-
 import org.junit.Test;
 
 import org.springframework.context.annotation.Bean;

--- a/src/test/java/org/springframework/guice/module/SpringModuleWrappedTests.java
+++ b/src/test/java/org/springframework/guice/module/SpringModuleWrappedTests.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.guice.annotation.EnableGuiceModules;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpringModuleWrappedTests {
 
@@ -36,7 +36,7 @@ public class SpringModuleWrappedTests {
 	public void testDependenciesFromWrappedModule() {
 		Injector injector = Guice.createInjector(
 				new SpringModule(BeanFactoryProvider.from(TestConfig.class, ModuleProviderConfig.class)));
-		assertNotNull(injector.getInstance(Baz.class));
+		assertThat(injector.getInstance(Baz.class)).isNotNull();
 	}
 
 	@Configuration


### PR DESCRIPTION
> This PR depends on changes included in #99 **(so #99 must be merged before this one)**, creating these as separate PRs just because its just a large diff for each one. Check out the individual commits [here](https://github.com/spring-projects/spring-guice/commit/8200b8c32400119f0376e7e5e76840c94b068117) and [here](https://github.com/spring-projects/spring-guice/commit/9aacf97448c5f00a618ffc3b128fb850f7f48e16) for the parts that actually matter.

This just upgrades all tests to use JUnit 5, and changes their assertions to use AssertJ to match the checkstyle rules in spring-javaformat. Now that we are on AssertJ, I removed the exclusion for that rule from `checkstyle.xml`

I also upgraded the surefire plugin version to one that better works with JUnit 5
