### PR TITLE
Always use the Named key when looking up a Guice object in the GuiceAutowireCandidateResolver

### DIFF
--- a/src/main/java/org/springframework/guice/module/GuiceAutowireCandidateResolver.java
+++ b/src/main/java/org/springframework/guice/module/GuiceAutowireCandidateResolver.java
@@ -112,16 +112,14 @@ class GuiceAutowireCandidateResolver extends ContextAnnotationAutowireCandidateR
 			public Object getTarget() {
 				Object target = null;
 				if (this.isGuiceResolvable.isPresent() && this.isGuiceResolvable.get()) {
-					target = GuiceAutowireCandidateResolver.this.injectorProvider.get()
-							.getInstance(Key.get(descriptor.getResolvableType().getType()));
+					target = targetGuiceObject();
 				}
 				else {
 					try {
 						target = beanFactory.doResolveDependency(descriptor, beanName, null, null);
 					}
 					catch (NoSuchBeanDefinitionException ex) {
-						Key<?> key = guiceInstanceResolverKey();
-						target = GuiceAutowireCandidateResolver.this.injectorProvider.get().getInstance(key);
+						target = targetGuiceObject();
 						this.isGuiceResolvable = Optional.of(true);
 					}
 				}
@@ -130,6 +128,11 @@ class GuiceAutowireCandidateResolver extends ContextAnnotationAutowireCandidateR
 							"Optional dependency not present for lazy injection point");
 				}
 				return target;
+			}
+
+			private Object targetGuiceObject() {
+				Key<?> key = guiceInstanceResolverKey();
+				return GuiceAutowireCandidateResolver.this.injectorProvider.get().getInstance(key);
 			}
 
 			private Key<?> guiceInstanceResolverKey() {

--- a/src/test/java/org/springframework/guice/PartialInjectionTests.java
+++ b/src/test/java/org/springframework/guice/PartialInjectionTests.java
@@ -71,6 +71,26 @@ public class PartialInjectionTests {
 		assertThat(example.getUnnamedMessage()).isEqualTo("apple");
 	}
 
+	@Test
+	void shouldResolveNamedComponentOnSecondInjectWhenUsingConstructorInjection() {
+		Injector injector = guiceInjectorWithSpringBean(ConstructorInjectionExample.class);
+
+		ConstructorInjectionExample example = injector.getInstance(ConstructorInjectionExample.class);
+
+		example.getNamedMessage();
+		assertThat(example.getNamedMessage()).isEqualTo("banana");
+	}
+
+	@Test
+	void shouldResolveNamedComponentOnSecondInjectWhenUsingSetterInjection() {
+		Injector injector = guiceInjectorWithSpringBean(SetterInjectionExample.class);
+
+		SetterInjectionExample example = injector.getInstance(SetterInjectionExample.class);
+
+		example.getNamedMessage();
+		assertThat(example.getNamedMessage()).isEqualTo("banana");
+	}
+
 	private Injector guiceInjectorWithSpringBean(Class<?> classForContext) {
 		Class<?>[] components = new Class<?>[] { classForContext };
 		BeanFactoryProvider beanFactoryProvider = BeanFactoryProvider.from(components);


### PR DESCRIPTION
To resolve issue https://github.com/spring-projects/spring-guice/issues/102 we changed the Guice instance key to include the `Qualifier` value if it exists. The code we updated runs on the first iteration of finding an instance. After an instance has been found in Guice the code takes another path. This second path was not updated. That means `Named` dependencies are found on the first iteration but not subsequent. This PR fixes that behavior so `Named` dependencies are always found. Sorry that was missing in the first PR! 