### PR TITLE
Address duplicate binding issues

### DIFF
--- a/src/main/java/org/springframework/guice/module/SpringModule.java
+++ b/src/main/java/org/springframework/guice/module/SpringModule.java
@@ -168,9 +168,6 @@ public class SpringModule extends AbstractModule {
 					type = clazz;
 				}
 
-				if (type == null) {
-					continue;
-				}
 				Provider<?> typeProvider = BeanFactoryProvider.typed(beanFactory, type, bindingAnnotation);
 				Provider<?> namedProvider = BeanFactoryProvider.named(beanFactory, name, type, bindingAnnotation);
 
@@ -305,7 +302,8 @@ public class SpringModule extends AbstractModule {
 		if (!this.matcher.matches(name, type)) {
 			return;
 		}
-		if (type.getTypeName().startsWith("com.google.inject")) {
+		String typeName = type.getTypeName();
+		if (typeName.startsWith("com.google.inject") || typeName.startsWith("javax.inject.Provider")) {
 			return;
 		}
 		if (type instanceof ParameterizedType) {
@@ -318,13 +316,11 @@ public class SpringModule extends AbstractModule {
 		}
 		Key<?> key = bindingAnnotation.map((a) -> (Key<Object>) Key.get(type, a)).orElse((Key<Object>) Key.get(type));
 		StageTypeKey stageTypeKey = new StageTypeKey(binder.currentStage(), key);
-		if (this.bound.get(stageTypeKey) == null) {
-			// Only bind one provider for each type
-
+		// Only bind one provider for each type
+		if (this.bound.put(stageTypeKey, typeProvider) == null) {
 			binder.withSource(SPRING_GUICE_SOURCE).bind(key).toProvider(typeProvider);
-			this.bound.put(stageTypeKey, typeProvider);
 		}
-		// But allow binding to named beans if not already bound
+		// Allow binding to named beans if not already bound
 		if (!name.equals(getNameFromBindingAnnotation(bindingAnnotation))) {
 			binder.withSource(SPRING_GUICE_SOURCE).bind(TypeLiteral.get(type)).annotatedWith(Names.named(name))
 					.toProvider(namedProvider);
@@ -375,6 +371,11 @@ public class SpringModule extends AbstractModule {
 			result = prime * result + ((this.key == null) ? 0 : this.key.hashCode());
 			result = prime * result + ((this.stage == null) ? 0 : this.stage.hashCode());
 			return result;
+		}
+
+		@Override
+		public String toString() {
+			return "StageTypeKey[key=" + this.key + ", stage=" + this.stage + "]";
 		}
 
 	}

--- a/src/test/java/org/springframework/guice/AdhocTestSuite.java
+++ b/src/test/java/org/springframework/guice/AdhocTestSuite.java
@@ -28,7 +28,7 @@ import org.springframework.guice.annotation.EnableGuiceModulesTests;
  * @author Dave Syer
  */
 @Suite
-@SelectClasses({ BindingDeduplicationTests.class, EnableGuiceModulesTests.class })
+@SelectClasses({ MapBindingDeduplicationTests.class, BindingDeduplicationTests.class, EnableGuiceModulesTests.class })
 @Disabled
 public class AdhocTestSuite {
 

--- a/src/test/java/org/springframework/guice/MapBindingDeduplicationTests.java
+++ b/src/test/java/org/springframework/guice/MapBindingDeduplicationTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.guice;
+
+import java.util.Map;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.multibindings.MapBinder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ResolvableType;
+import org.springframework.guice.annotation.EnableGuiceModules;
+import org.springframework.guice.module.SpringModule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapBindingDeduplicationTests {
+
+	@AfterAll
+	public static void cleanUp() {
+		System.clearProperty("spring.guice.dedup");
+	}
+
+	@Test
+	public void mapBindingGuiceOnly() {
+		System.setProperty("spring.guice.dedup", "false");
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				MapBindingGuiceOnlyTestsConfig.class);
+
+		String[] beanNamesForType = context
+				.getBeanNamesForType(ResolvableType.forClassWithGenerics(Map.class, String.class, Provider.class));
+		@SuppressWarnings("unchecked")
+		Map<String, Provider<Dependency>> dependencyProvider = (Map<String, Provider<Dependency>>) context
+				.getBean(beanNamesForType[0]);
+
+		assertThat(dependencyProvider.size()).isEqualTo(2);
+		assertThat(dependencyProvider.get("someQualifier").get()).isInstanceOf(SomeDependency.class);
+
+		context.close();
+	}
+
+	@Test
+	public void mapBindingConflictingConcreteClass() {
+		System.setProperty("spring.guice.dedup", "true");
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				MapBindingConcreteClassTestsConfig.class);
+
+		String[] beanNamesForType = context
+				.getBeanNamesForType(ResolvableType.forClassWithGenerics(Map.class, String.class, Provider.class));
+		@SuppressWarnings("unchecked")
+		Map<String, Provider<Dependency>> dependencyProvider = (Map<String, Provider<Dependency>>) context
+				.getBean(beanNamesForType[0]);
+
+		assertThat(dependencyProvider.size()).isEqualTo(2);
+		assertThat(dependencyProvider.get("someQualifier").get()).isInstanceOf(SomeDependency.class);
+
+		SomeDependency someDependency = context.getBean(SomeDependency.class);
+		assertThat(someDependency.getSource()).isEqualTo(SpringModule.SPRING_GUICE_SOURCE);
+
+		context.close();
+	}
+
+	interface Dependency {
+
+	}
+
+	public static class SomeDependency implements Dependency {
+
+		private String source = "guice";
+
+		public void setSource(String source) {
+			this.source = source;
+		}
+
+		public String getSource() {
+			return this.source;
+		}
+
+	}
+
+	public static class SomeOptionalDependency implements Dependency {
+
+	}
+
+	@EnableGuiceModules
+	@Configuration
+	static class MapBindingGuiceOnlyTestsConfig {
+
+		@Bean
+		static Module module() {
+			return new AbstractModule() {
+				@Override
+				protected void configure() {
+					MapBinder<String, Dependency> bindings = MapBinder.newMapBinder(binder(), String.class,
+							Dependency.class);
+					bindings.addBinding("someQualifier").to(SomeDependency.class);
+					bindings.addBinding("someOtherQualifier").to(SomeOptionalDependency.class);
+				}
+			};
+		}
+
+	}
+
+	@EnableGuiceModules
+	@Configuration
+	static class MapBindingConcreteClassTestsConfig {
+
+		@Bean
+		SomeDependency dependency() {
+			SomeDependency someDependency = new SomeDependency();
+			someDependency.setSource(SpringModule.SPRING_GUICE_SOURCE);
+			return someDependency;
+		}
+
+		@Bean
+		static Module module() {
+			return new AbstractModule() {
+				@Override
+				protected void configure() {
+					MapBinder<String, Dependency> bindings = MapBinder.newMapBinder(binder(), String.class,
+							Dependency.class);
+					bindings.addBinding("someQualifier").to(SomeDependency.class);
+					// Intentionally duplicate the binding to ensure that every key is
+					// available after deduplication
+					bindings.addBinding("someQualifier").to(SomeDependency.class);
+					bindings.addBinding("someOtherQualifier").to(SomeOptionalDependency.class);
+				}
+			};
+		}
+
+	}
+
+}


### PR DESCRIPTION
Address several issues we found with duplicate Spring beans and Guice binding deduplication when attempting to upgrade to 2.0.0.

- Deduplicate `LinkedKeyBinding` by `Binding::getKey` before falling back to the linked key if it didn't deduplicate the first time
- Rather than just dropping the Guice binding when deduplicating, rekey the Spring Guice binding for every key. Otherwise runtime failures may occur where a binding is referenced by that specific key, as is the case with map bindings
- Avoid registering duplicate beans for unique multibindings
- Avoid registering a duplicate bean for an untargetted binding where a linked binding also exists for that type
- Beans that implement `Provided` cause configuration failures
- Guice configuration errors are not surfaced by `ModuleRegistryConfiguration` causing confusing downstream errors

Failing tests were added for each use case before making the changes. Some of these cases are quite subtle because they take specific combinations of bean method signatures, including by interface, public and non-public concrete classes, etc. Those tests were developed based on failing binding on a Guice/Spring Boot application with 8,782 bindings, 150 of those now correctly handled as duplicates.

## LinkedKeyBinding

`LinkedKeyBinding::getLinkedKey` won't necessarily be the duplicating key, in fact it's more likely that `Binding::getKey` is the interface we need to deduplicate on, and the linked the implementation for the concrete class. So we need to check the binding key first, before falling back to the linked key.

## Map Binding

`RealMapBinder$ProviderMapEntry` keeps a reference to the original binding key, and the previous deduplication method would drop all duplicate Guice bindings, causing this NPE:
```
java.lang.NullPointerException
	at com.google.inject.internal.RealMapBinder$ProviderMapEntry.initialize(RealMapBinder.java:1241)
	at com.google.inject.internal.InternalProviderInstanceBindingImpl.initialize(InternalProviderInstanceBindingImpl.java:64)
	at com.google.inject.internal.InjectorImpl.initializeBinding(InjectorImpl.java:591)
	at com.google.inject.internal.AbstractBindingProcessor$Processor.initializeBinding(AbstractBindingProcessor.java:176)
	at com.google.inject.internal.AbstractBindingProcessor$Processor.lambda$scheduleInitialization$0(AbstractBindingProcessor.java:163)
	at com.google.inject.internal.ProcessedBindingData.initializeBindings(ProcessedBindingData.java:49)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:126)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:110)
	at com.google.inject.Guice.createInjector(Guice.java:87)
	at com.google.inject.Guice.createInjector(Guice.java:78)
	at com.netflix.governator.LifecycleInjectorCreator.createInjector(LifecycleInjectorCreator.java:100)
	at com.netflix.governator.LifecycleInjectorCreator.createInjector(LifecycleInjectorCreator.java:38)
	at com.netflix.governator.InjectorBuilder.createInjector(InjectorBuilder.java:209)
	at com.netflix.governator.InjectorBuilder.createInjector(InjectorBuilder.java:223)
	at com.netflix.springboot.governator.GovernatorInjectorFactory.createInjector(GovernatorAutoConfiguration.java:67)
	at org.springframework.guice.annotation.ModuleRegistryConfiguration$GuiceInjectorInitializer.createInjector(ModuleRegistryConfiguration.java:376)
	at org.springframework.guice.annotation.ModuleRegistryConfiguration$GuiceInjectorInitializer.postProcessAfterInitialization(ModuleRegistryConfiguration.java:351)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsAfterInitialization(AbstractAutowireCapableBeanFactory.java:455)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1808)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:620)
	... 73 more
```

The Spring binding is now duplicated with the original key. Every Guice implementation extends `BindingImpl` and there's no way of registering your own `Binding` implementation, so we intentionally fail fast if that ever is not the case.

## Multibindings

Multibindings register a unique internally annotated `Element` binding for each binding allowing a unique instance per binding. Deduplication does not apply, due to the unique annotation, so we also avoid registering with Spring because it causes duplicate beans.

## Untargetted Bindings

Untargetted bindings, for instance to mark a concrete class as a singleton would duplicate beans when that concrete class was bound to an interface. An attempt to inject by that interface would fail with:

```
org.springframework.beans.factory.NoUniqueBeanDefinitionException: No qualifying bean of type 'org.springframework.guice.BindingDeduplicationTests$FirstInterface' available: expected single matching bean but found 2: org.springframework.guice.BindingDeduplicationTests$MultiInterfaceSingleton,org.springframework.guice.BindingDeduplicationTests$FirstInterface
```

This now considers the linked bindings and only registered untargetted bindings if there are no other bindings linking to it.

## Optional Bindings

Optional bindings register a binding with the`RealOptionalBinder$Default` annotation and need to be specifically excluded.

## Provider implementations

We found some user code that was using `javax.inject.Provider` like a `Supplier`, which causes configuration to fail with:
```
Caused by: java.lang.ClassCastException: java.lang.Class cannot be cast to java.lang.reflect.ParameterizedType
	at com.google.inject.internal.MoreTypes.canonicalizeForKey(MoreTypes.java:95)
	at com.google.inject.Key.<init>(Key.java:125)
	at com.google.inject.Key.get(Key.java:239)
	at org.springframework.guice.module.SpringModule.bindConditionally(SpringModule.java:316)
	at org.springframework.guice.module.SpringModule.bind(SpringModule.java:179)
	at org.springframework.guice.module.SpringModule.configure(SpringModule.java:130)
	at com.google.inject.AbstractModule.configure(AbstractModule.java:66)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:409)
	at com.google.inject.spi.Elements.getElements(Elements.java:108)
	at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:160)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
	... 82 more
```

We've had them migrate their code but figured we'd prevent these from being accidentally bound. This problem also surfaced a problem with error messages not being checked for, which results in a known bad configuration being reused and adding additional errors caused by the added bindings:

```
1) An exception was caught and reported. Message: Class cannot be cast to ParameterizedType
  at ModuleRegistryConfiguration.postProcessBeanDefinitionRegistry(ModuleRegistryConfiguration.java:131)

2) [Guice/BindingToProvider]: Binding to Provider is not allowed.
  at spring-guice
      \_ installed by: Modules$CombinedModule -> Elements$ElementsAsModule -> SpringModule

3) [Guice/BindingToProvider]: Binding to Provider is not allowed.
  at spring-guice
      \_ installed by: Modules$CombinedModule -> Elements$ElementsAsModule -> SpringModule
```