### PR TITLE
Avoid bean name collisions when using an annotation that wraps @Named

### DIFF
--- a/src/main/java/org/springframework/guice/annotation/ModuleRegistryConfiguration.java
+++ b/src/main/java/org/springframework/guice/annotation/ModuleRegistryConfiguration.java
@@ -264,7 +264,19 @@ class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor
 			return ((javax.inject.Named) key.getAnnotation()).value();
 		}
 		else if (key.getAnnotationType() != null) {
-			return key.getAnnotationType().getName();
+			String value = key.getAnnotationType().getName();
+
+			if (key.getAnnotation() != null) {
+				// Edge case when the Named annotation is wrapped
+				String annotationString = key.getAnnotation().toString();
+				String wrappedNamedValue = substringBetween(annotationString, "@com.google.inject.name.Named(\"",
+						"\")");
+				if (wrappedNamedValue != null) {
+					value = wrappedNamedValue + "_" + value;
+				}
+			}
+
+			return value;
 		}
 		else {
 			return null;
@@ -359,6 +371,20 @@ class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor
 		catch (IllegalAccessException | InvocationTargetException ex) {
 			throw new RuntimeException(ex);
 		}
+	}
+
+	private static String substringBetween(String str, String open, String close) {
+		if (str == null || open == null || close == null) {
+			return null;
+		}
+		int start = str.indexOf(open);
+		if (start != -1) {
+			int end = str.indexOf(close, start + open.length());
+			if (end != -1) {
+				return str.substring(start + open.length(), end);
+			}
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Example using governator [@ProvidesWithAdvice](https://github.com/Netflix/governator/blob/master/governator-providers/src/main/java/com/netflix/governator/providers/ProvidesWithAdvice.java).

Using this pattern will create a key with AdviceElement annotation which wraps `@Named`.
i.e.
```
Key[type=com.netflix.abrosssbn3.MyPojo, annotation=@AdviceElementImpl(name=@com.google.inject.name.Named("AbrossTest2"), type=SOURCE, id=2)]
```

The current state ignores the wrapped `@Named` value and generates a bean name similar to this:
```
com.netflix.governator.providers.AdviceElement_com.netflix.abrosssbn3.MyPojo
```

Therefore, having multiple bindings for `MyPojo` class with @ProvidesWithAdvice and different `@Named` values will all resolve to the same bean name and cause a collision.

Fixing this edge case by extracting the inner `@Named` value.

