### PR TITLE
Lower prio of ModuleRegistryConfig slightly

### DIFF
--- a/src/main/java/org/springframework/guice/annotation/ModuleRegistryConfiguration.java
+++ b/src/main/java/org/springframework/guice/annotation/ModuleRegistryConfiguration.java
@@ -85,7 +85,7 @@ import org.springframework.guice.module.SpringModule;
  *
  */
 @Configuration(proxyBeanMethods = false)
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
 class ModuleRegistryConfiguration implements BeanDefinitionRegistryPostProcessor, ApplicationContextAware {
 
 	private static final String SPRING_GUICE_DEDUPE_BINDINGS_PROPERTY_NAME = "spring.guice.dedup";


### PR DESCRIPTION
This allows user configurations to come in before any configure() methods are called on the modules, avoiding potential side effects in legacy code

Alternative for #111
